### PR TITLE
Issue-13 - Sas uri added when sending message

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configuration and registration with SAS uri
 
 ```c#
 var sender = new MessageSender(connectionString, queueName);
-var config = new AzureStorageAttachmentConfiguration(storageConnectionString, sasTokenValidInSeconds: 60*60*24, sasUri:"myProperty");
+var config = new AzureStorageAttachmentConfiguration(storageConnectionString, sasTokenValidInSeconds: 60*60*24, messagePropertyToIdentifySasUri:"myProperty");
 sender.RegisterAzureStorageAttachmentPlugin(config);
 ```  
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ receiver.RegisterAzureStorageAttachmentPlugin(config);
 var msg = await receiver.ReceiveAsync().ConfigureAwait(false);
 // msg will contain the original payload
 ```
+
 ### Sending a message without exposing the storage account to receivers
 
 Configuration and registration with SAS uri

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Configuration and registration with SAS uri
 
 ```c#
 var sender = new MessageSender(connectionString, queueName);
-var config = new AzureStorageAttachmentConfiguration(storageConnectionString, sasTokenValidInSeconds: 60*60*24, messagePropertyToIdentifySasUri:"myProperty");
+var config = new AzureStorageAttachmentConfiguration(storageConnectionString)
+	.WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(4), messagePropertyToIdentifySasUri: "mySasUriProperty");
 sender.RegisterAzureStorageAttachmentPlugin(config);
 ```  
 
@@ -94,7 +95,7 @@ new AzureStorageAttachmentConfiguration(storageConnectionString, messageProperty
 Default sas uri name is "$attachment.sas.uri".
 
 ```c#
-new AzureStorageAttachmentConfiguration(storageConnectionString, sasUri: "mySasUri");
+new AzureStorageAttachmentConfiguration(storageConnectionString).WithSasUri(messagePropertyToIdentifySasUri: "mySasUriProperty");
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Configuration and registration
 var sender = new MessageSender(connectionString, queueName);
 var config = new AzureStorageAttachmentConfiguration(storageConnectionString);
 sender.RegisterAzureStorageAttachmentPlugin(config);
-```
+```        
 
 Sending
 
@@ -34,6 +34,7 @@ var payloadAsBytes = Encoding.UTF8.GetBytes(serialized);
 var message = new Message(payloadAsBytes);
 ```
 
+
 Receiving
 
 ```c#
@@ -42,6 +43,34 @@ receiver.RegisterAzureStorageAttachmentPlugin(config);
 var msg = await receiver.ReceiveAsync().ConfigureAwait(false);
 // msg will contain the original payload
 ```
+### Sending a message without exposing the storage account to receivers
+
+Configuration and registration with SAS uri
+
+```c#
+var sender = new MessageSender(connectionString, queueName);
+var config = new AzureStorageAttachmentConfiguration(storageConnectionString, sasTokenValidInSeconds: 60*60*24, sasUri:"myProperty");
+sender.RegisterAzureStorageAttachmentPlugin(config);
+```  
+
+Sending
+
+```c#
+var payload = new MyMessage { ... }; 
+var serialized = JsonConvert.SerializeObject(payload);
+var payloadAsBytes = Encoding.UTF8.GetBytes(serialized);
+var message = new Message(payloadAsBytes);
+```
+
+Receive
+
+```c#
+var receiver = new MessageReceiver(connectionString, entityPath, ReceiveMode.ReceiveAndDelete);
+var msg = await receiver.ReceiveAsync().ConfigureAwait(false);
+//msg will contain a user property 'myProperty'
+//Receiver can use any http client to download the payload
+```
+
 
 ### Configure blobs container name
 
@@ -57,6 +86,14 @@ Default container name is "$attachment.blob".
 
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, messagePropertyToIdentifyAttachmentBlob: "myblob");
+```
+
+### Configure message property for sas uri to attachment blob
+
+Default sas uri name is "$attachment.sas.uri".
+
+```c#
+new AzureStorageAttachmentConfiguration(storageConnectionString, sasUri: "mySasUri");
 ```
 
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -9,11 +9,12 @@
         [Fact]
         public void Should_apply_defaults_for_missing_arguments()
         {
-            var configuration = new AzureStorageAttachmentConfiguration("connectionString");
+            var configuration = new AzureStorageAttachmentConfiguration("connectionString")
+                .WithSasUri();
             Assert.Equal("connectionString", configuration.ConnectionString);
             Assert.NotEmpty(configuration.ContainerName);
             Assert.NotEmpty(configuration.MessagePropertyToIdentifyAttachmentBlob);
-            Assert.Equal(0, configuration.SasTokensValidInSeconds);
+            Assert.Equal(TimeSpan.FromDays(7).Days, configuration.SasTokenValidationTime.Value.Days);
             Assert.Equal("$attachment.sas.uri", configuration.MessagePropertyForSasUri);
             Assert.True(configuration.MessageMaxSizeReachedCriteria(new Message()));
         }
@@ -21,7 +22,7 @@
         [Fact]
         public void Should_not_accept_negative_token_validation_time()
         {
-            Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration("connectionString", sasTokenValidInSeconds: -123));
+            Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration("connectionString").WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(-4)));
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceBus.AttachmentPlugin.Tests
 {
+    using System;
     using Microsoft.Azure.ServiceBus;
     using Xunit;
 
@@ -12,7 +13,15 @@
             Assert.Equal("connectionString", configuration.ConnectionString);
             Assert.NotEmpty(configuration.ContainerName);
             Assert.NotEmpty(configuration.MessagePropertyToIdentifyAttachmentBlob);
+            Assert.Equal(0, configuration.SasTokensValidInSeconds);
+            Assert.Equal("$attachment.sas.uri", configuration.MessagePropertyForSasUri);
             Assert.True(configuration.MessageMaxSizeReachedCriteria(new Message()));
+        }
+
+        [Fact]
+        public void Should_not_accept_invalid_arguments()
+        {
+            Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration("connectionString", sasTokenValidInSeconds: -123));
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -19,7 +19,7 @@
         }
 
         [Fact]
-        public void Should_not_accept_invalid_arguments()
+        public void Should_not_accept_negative_token_validation_time()
         {
             Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration("connectionString", sasTokenValidInSeconds: -123));
         }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
@@ -90,5 +90,23 @@
 
             Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
         }
+
+        [Fact]
+        public async Task Shoud_not_set_sas_uri_by_default()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Null(result.Body);
+            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
+            Assert.False(message.UserProperties.ContainsKey("$attachment.sas.uri"));
+        }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -20,7 +20,7 @@ namespace ServiceBus.AttachmentPlugin.Tests
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id", sasTokenValidInSeconds: 60*60*24, sasUri: "mySasUriProperty"));
+                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id", sasTokenValidInSeconds: 60*60*24, messagePropertyToIdentifySasUri: "mySasUriProperty"));
             var result = await plugin.BeforeMessageSend(message);
 
             Assert.Null(result.Body);

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Text;
+
+namespace ServiceBus.AttachmentPlugin.Tests
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Xunit;
+
+    public class When_sending_message_with_sas_uri : IClassFixture<AzureStorageEmulatorFixture>
+    {
+        [Fact]
+        public async Task Should_contain_no_sas_uri_if_not_specified()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Null(result.Body);
+            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
+            Assert.False(message.UserProperties.ContainsKey("$sas.uri"));
+        }
+
+        [Fact]
+        public async Task Should_set_sas_uri_when_specified()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id", sasTokenValidInSeconds: 60*60*24, sasUri: "mySasUriProperty"));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Null(result.Body);
+            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
+            Assert.True(message.UserProperties.ContainsKey("mySasUriProperty"));
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -9,23 +9,6 @@ namespace ServiceBus.AttachmentPlugin.Tests
 
     public class When_sending_message_with_sas_uri : IClassFixture<AzureStorageEmulatorFixture>
     {
-        [Fact]
-        public async Task Should_contain_no_sas_uri_if_not_specified()
-        {
-            var payload = "payload";
-            var bytes = Encoding.UTF8.GetBytes(payload);
-            var message = new Message(bytes)
-            {
-                MessageId = Guid.NewGuid().ToString(),
-            };
-            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
-            var result = await plugin.BeforeMessageSend(message);
-
-            Assert.Null(result.Body);
-            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
-            Assert.False(message.UserProperties.ContainsKey("$sas.uri"));
-        }
 
         [Fact]
         public async Task Should_set_sas_uri_when_specified()

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -20,7 +20,8 @@ namespace ServiceBus.AttachmentPlugin.Tests
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id", sasTokenValidInSeconds: 60*60*24, messagePropertyToIdentifySasUri: "mySasUriProperty"));
+                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id")
+                .WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(4), messagePropertyToIdentifySasUri: "mySasUriProperty"));
             var result = await plugin.BeforeMessageSend(message);
 
             Assert.Null(result.Body);

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -10,8 +10,8 @@
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
-        /// <param name="sasUri"></param>
-        /// <param name="sasTokenValidInSeconds"></param>
+        /// <param name="sasUri">The message user property to use for the generated sas uri.</param>
+        /// <param name="sasTokenValidInSeconds">In seconds, how long the generated sas uri should be valid.</param>
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(string connectionString,
             string containerName = "attachments",

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -10,27 +10,21 @@
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
-        /// <param name="messagePropertyToIdentifySasUri">The message user property to use for the generated sas uri.</param>
-        /// <param name="sasTokenValidInSeconds">In seconds, how long the generated sas uri should be valid.</param>
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(string connectionString,
             string containerName = "attachments",
             string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
-            string messagePropertyToIdentifySasUri = "$attachment.sas.uri",
-            long sasTokenValidInSeconds = 0,
+            
             Func<Message, bool> messageMaxSizeReachedCriteria = null)
         {
             Guard.AgainstEmpty(nameof(containerName), containerName);
             Guard.AgainstEmpty(nameof(messagePropertyToIdentifyAttachmentBlob), messagePropertyToIdentifyAttachmentBlob);
-            Guard.AgainstNegative(nameof(sasTokenValidInSeconds), sasTokenValidInSeconds);
             ConnectionString = connectionString;
             ContainerName = containerName;
-            MessagePropertyForSasUri = messagePropertyToIdentifySasUri;
-            SasTokensValidInSeconds = sasTokenValidInSeconds;
             MessagePropertyToIdentifyAttachmentBlob = messagePropertyToIdentifyAttachmentBlob;
             MessageMaxSizeReachedCriteria = GetMessageMaxSizeReachedCriteria(messageMaxSizeReachedCriteria);
         }
-
+        
         Func<Message, bool> GetMessageMaxSizeReachedCriteria(Func<Message, bool> messageMaxSizeReachedCriteria)
         {
             if (messageMaxSizeReachedCriteria == null)
@@ -54,9 +48,9 @@
 
         internal string ContainerName { get; }
 
-        internal string MessagePropertyForSasUri { get; }
+        internal string MessagePropertyForSasUri { get; set; }
 
-        internal long SasTokensValidInSeconds { get; }
+        internal TimeSpan? SasTokenValidationTime { get; set; }
 
         internal string MessagePropertyToIdentifyAttachmentBlob { get; }
 

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -22,7 +22,7 @@
         {
             Guard.AgainstEmpty(nameof(containerName), containerName);
             Guard.AgainstEmpty(nameof(messagePropertyToIdentifyAttachmentBlob), messagePropertyToIdentifyAttachmentBlob);
-            Guard.AgainstNonPositive(nameof(sasTokenValidInSeconds), sasTokenValidInSeconds);
+            Guard.AgainstNegative(nameof(sasTokenValidInSeconds), sasTokenValidInSeconds);
             ConnectionString = connectionString;
             ContainerName = containerName;
             MessagePropertyForSasUri = sasUri;

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -10,13 +10,13 @@
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
-        /// <param name="sasUri">The message user property to use for the generated sas uri.</param>
+        /// <param name="messagePropertyToIdentifySasUri">The message user property to use for the generated sas uri.</param>
         /// <param name="sasTokenValidInSeconds">In seconds, how long the generated sas uri should be valid.</param>
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(string connectionString,
             string containerName = "attachments",
             string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
-            string sasUri = "$attachment.sas.uri",
+            string messagePropertyToIdentifySasUri = "$attachment.sas.uri",
             long sasTokenValidInSeconds = 0,
             Func<Message, bool> messageMaxSizeReachedCriteria = null)
         {
@@ -25,7 +25,7 @@
             Guard.AgainstNegative(nameof(sasTokenValidInSeconds), sasTokenValidInSeconds);
             ConnectionString = connectionString;
             ContainerName = containerName;
-            MessagePropertyForSasUri = sasUri;
+            MessagePropertyForSasUri = messagePropertyToIdentifySasUri;
             SasTokensValidInSeconds = sasTokenValidInSeconds;
             MessagePropertyToIdentifyAttachmentBlob = messagePropertyToIdentifyAttachmentBlob;
             MessageMaxSizeReachedCriteria = GetMessageMaxSizeReachedCriteria(messageMaxSizeReachedCriteria);

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -10,16 +10,23 @@
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
+        /// <param name="sasUri"></param>
+        /// <param name="sasTokenValidInSeconds"></param>
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(string connectionString,
             string containerName = "attachments",
             string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            string sasUri = "$attachment.sas.uri",
+            long sasTokenValidInSeconds = 0,
             Func<Message, bool> messageMaxSizeReachedCriteria = null)
         {
             Guard.AgainstEmpty(nameof(containerName), containerName);
             Guard.AgainstEmpty(nameof(messagePropertyToIdentifyAttachmentBlob), messagePropertyToIdentifyAttachmentBlob);
+            Guard.AgainstNonPositive(nameof(sasTokenValidInSeconds), sasTokenValidInSeconds);
             ConnectionString = connectionString;
             ContainerName = containerName;
+            MessagePropertyForSasUri = sasUri;
+            SasTokensValidInSeconds = sasTokenValidInSeconds;
             MessagePropertyToIdentifyAttachmentBlob = messagePropertyToIdentifyAttachmentBlob;
             MessageMaxSizeReachedCriteria = GetMessageMaxSizeReachedCriteria(messageMaxSizeReachedCriteria);
         }
@@ -46,6 +53,10 @@
         internal string ConnectionString { get; }
 
         internal string ContainerName { get; }
+
+        internal string MessagePropertyForSasUri { get; }
+
+        internal long SasTokensValidInSeconds { get; }
 
         internal string MessagePropertyToIdentifyAttachmentBlob { get; }
 

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -1,0 +1,37 @@
+﻿namespace ServiceBus.AttachmentPlugin
+{
+    using System;
+
+    /// <summary>
+    /// Extension method for setting up the SAS uri configuration.
+    /// </summary>
+    public static class AzureStorageAttachmentConfigurationExtensions
+    {
+        const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
+        static TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
+
+        /// <summary>
+        /// Adds sas uri configuration.
+        /// </summary>
+        /// <param name="azureStorageAttachmentConfiguration"></param>
+        /// <param name="messagePropertyToIdentifySasUri">The message property where the sas uri is set.</param>
+        /// <param name="sasTokenValidationTime">The time the sas uri is valid.</param>
+        /// <returns></returns>
+        public static AzureStorageAttachmentConfiguration WithSasUri(
+            this AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, 
+            string messagePropertyToIdentifySasUri = DefaultMessagePropertyToIdentitySasUri, 
+            TimeSpan? sasTokenValidationTime = null)
+        {
+            if (sasTokenValidationTime == null)
+            {
+                sasTokenValidationTime = DefaultSasTokenValidationTime;
+            }
+            Guard.AgainstNegativeTime(nameof(sasTokenValidationTime), sasTokenValidationTime);
+
+            azureStorageAttachmentConfiguration.MessagePropertyForSasUri = messagePropertyToIdentifySasUri;
+            azureStorageAttachmentConfiguration.SasTokenValidationTime = sasTokenValidationTime.Value;
+
+            return azureStorageAttachmentConfiguration;
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -13,5 +13,7 @@
         {
             client.RegisterPlugin(new AzureStorageAttachment(configuration));
         }
+
+
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/Guard.cs
+++ b/src/ServiceBus.AttachmentPlugin/Guard.cs
@@ -18,5 +18,13 @@ namespace ServiceBus.AttachmentPlugin
                 throw new ArgumentNullException(argumentName);
             }
         }
+
+        public static void AgainstNonPositive(string argumentName, long value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentException(argumentName);
+            }
+        }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/Guard.cs
+++ b/src/ServiceBus.AttachmentPlugin/Guard.cs
@@ -19,9 +19,9 @@ namespace ServiceBus.AttachmentPlugin
             }
         }
 
-        public static void AgainstNegative(string argumentName, long value)
+        public static void AgainstNegativeTime(string argumentName, TimeSpan? value)
         {
-            if (value < 0)
+            if (value?.Ticks <= 0)
             {
                 throw new ArgumentException(argumentName);
             }

--- a/src/ServiceBus.AttachmentPlugin/Guard.cs
+++ b/src/ServiceBus.AttachmentPlugin/Guard.cs
@@ -19,9 +19,9 @@ namespace ServiceBus.AttachmentPlugin
             }
         }
 
-        public static void AgainstNonPositive(string argumentName, long value)
+        public static void AgainstNegative(string argumentName, long value)
         {
-            if (value <= 0)
+            if (value < 0)
             {
                 throw new ArgumentException(argumentName);
             }

--- a/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
+++ b/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
@@ -1,0 +1,27 @@
+﻿namespace ServiceBus.AttachmentPlugin
+{
+    using Microsoft.WindowsAzure.Storage.Blob;
+    using System;
+
+    static class TokenGenerator
+    {
+        static string GetBlobSasUri(CloudBlockBlob blob, TimeSpan timeSpan)
+        {
+            //Set the expiry time and permissions for the blob.
+            //In this case the start time is specified as a few minutes in the past, to mitigate clock skew.
+            //The shared access signature will be valid immediately.
+            var sasConstraints = new SharedAccessBlobPolicy
+            {
+                SharedAccessStartTime = DateTime.UtcNow.AddMinutes(-5),
+                SharedAccessExpiryTime = DateTime.UtcNow.Add(timeSpan),
+                Permissions = SharedAccessBlobPermissions.Read
+            };
+
+            //Generate the shared access signature on the blob, setting the constraints directly on the signature.
+            var sasBlobToken = blob.GetSharedAccessSignature(sasConstraints);
+
+            //Return the URI string for the container, including the SAS token.
+            return blob.Uri + sasBlobToken;
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
+++ b/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
@@ -5,7 +5,7 @@
 
     static class TokenGenerator
     {
-        static string GetBlobSasUri(CloudBlockBlob blob, TimeSpan timeSpan)
+        internal static string GetBlobSasUri(CloudBlockBlob blob, TimeSpan timeSpan)
         {
             //Set the expiry time and permissions for the blob.
             //In this case the start time is specified as a few minutes in the past, to mitigate clock skew.

--- a/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
+++ b/src/ServiceBus.AttachmentPlugin/TokenGenerator.cs
@@ -14,9 +14,8 @@
             {
                 SharedAccessStartTime = DateTime.UtcNow.AddMinutes(-5),
                 SharedAccessExpiryTime = DateTime.UtcNow.Add(timeSpan),
-                Permissions = SharedAccessBlobPermissions.Read
+                Permissions = SharedAccessBlobPermissions.Delete | SharedAccessBlobPermissions.Read
             };
-
             //Generate the shared access signature on the blob, setting the constraints directly on the signature.
             var sasBlobToken = blob.GetSharedAccessSignature(sasConstraints);
 


### PR DESCRIPTION
Added a tokengenerator to generate the Sas Uri.
Puts the sas uri in whichever user property you want, defaults to $attachment.sas.uri.
The TTL for the sas uri can be set.
