### PR TITLE
Enable keyvalue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Allows sending messages that exceed maximum size by implementing [Claim Check pa
 
 License: [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/LICENSE)
 
-Build status: [![Develop](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) [![Master](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) 
+Build status: [![Develop](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/develop.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) [![Master](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) 
 
 Opened issues: [![Issues](https://img.shields.io/github/issues-raw/badges/shields/website.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin)
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 Allows sending messages that exceed maximum size by implementing [Claim Check pattern](http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html) with Azure Storage.
 
-License: [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/LICENSE)
-
-Build status: [![Develop](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/develop.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) [![Master](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) 
-
-Opened issues: [![Issues](https://img.shields.io/github/issues-raw/badges/shields/website.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin)
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/LICENSE)
+[![develop build status](https://ci.appveyor.com/api/projects/status/kpw7nfmr4femj29y/branch/develop.svg?style=flat-square&pendingText=develop%20%E2%80%A3%20pending&failingText=develop%20%E2%80%A3%20failing&passingText=develop%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin)
+[![master build status](https://ci.appveyor.com/api/projects/status/kpw7nfmr4femj29y/branch/master.svg?style=flat-square&pendingText=master%20%E2%80%A3%20pending&failingText=master%20%E2%80%A3%20failing&passingText=master%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) 
+[![opened issues](https://img.shields.io/github/issues-raw/badges/shields/website.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin)
 
 ### Nuget package
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 Allows sending messages that exceed maximum size by implementing [Claim Check pattern](http://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html) with Azure Storage.
 
-### Nuget package [![NuGet Status](https://buildstats.info/nuget/ServiceBus.AttachmentPlugin?includePreReleases=true)](https://www.nuget.org/packages/ServiceBus.AttachmentPlugin/) [![Build Status](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/LICENSE) [![Issues](https://img.shields.io/github/issues-raw/badges/shields/website.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin)
+License: [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/LICENSE)
+
+Build status: [![Develop](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) [![Master](https://img.shields.io/appveyor/ci/seanfeldman/ServiceBus-AttachmentPlugin/master.svg?style=flat-square)](https://ci.appveyor.com/project/seanfeldman/ServiceBus-AttachmentPlugin) 
+
+Opened issues: [![Issues](https://img.shields.io/github/issues-raw/badges/shields/website.svg)](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin)
+
+### Nuget package
+
+[![NuGet Status](https://buildstats.info/nuget/ServiceBus.AttachmentPlugin?includePreReleases=true)](https://www.nuget.org/packages/ServiceBus.AttachmentPlugin/)
 
 Available here http://nuget.org/packages/ServiceBus.AttachmentPlugin
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ Default is to convert any body to attachment.
 new AzureStorageAttachmentConfiguration(storageConnectionString, message => message.Body.Length > 200 * 1024);
 ```
 
+### Configuring connection string provider
+
+When Storage connection string needs to be retrieved rather than passed in as a plain text, `AzureStorageAttachmentConfiguration` accepts implementation of `IProvideStorageConnectionString`.
+The plugin comes with a `PlainTextConnectionStringProvider` and can be used in the following way.
+
+```c#
+var provider = new PlainTextConnectionStringProvider("connectionString");
+var config = new AzureStorageAttachmentConfiguration(provider);
+```
+
 ## Who's trusting this add-in in production
 
 ![Codit](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/master/images/using/Codit.png)

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -9,9 +9,9 @@
         [Fact]
         public void Should_apply_defaults_for_missing_arguments()
         {
-            var configuration = new AzureStorageAttachmentConfiguration("connectionString")
+            var configuration = new AzureStorageAttachmentConfiguration(new PlainTextConnectionStringProvider("connectionString"))
                 .WithSasUri();
-            Assert.Equal("connectionString", configuration.ConnectionString);
+            Assert.Equal("connectionString", configuration.ConnectionStringProvider.GetConnectionString());
             Assert.NotEmpty(configuration.ContainerName);
             Assert.NotEmpty(configuration.MessagePropertyToIdentifyAttachmentBlob);
             Assert.Equal(AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime.Days, configuration.SasTokenValidationTime.Value.Days);
@@ -22,7 +22,8 @@
         [Fact]
         public void Should_not_accept_negative_token_validation_time()
         {
-            Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration("connectionString").WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(-4)));
+            Assert.Throws<ArgumentException>(() => 
+                new AzureStorageAttachmentConfiguration(new PlainTextConnectionStringProvider("connectionString")).WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(-4)));
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -1,17 +1,18 @@
 ﻿namespace ServiceBus.AttachmentPlugin.Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
     using Xunit;
 
     public class AzureStorageAttachmentConfigurationTests
     {
         [Fact]
-        public void Should_apply_defaults_for_missing_arguments()
+        public async Task Should_apply_defaults_for_missing_arguments()
         {
             var configuration = new AzureStorageAttachmentConfiguration(new PlainTextConnectionStringProvider("connectionString"))
                 .WithSasUri();
-            Assert.Equal("connectionString", configuration.ConnectionStringProvider.GetConnectionString());
+            Assert.Equal("connectionString", await configuration.ConnectionStringProvider.GetConnectionString());
             Assert.NotEmpty(configuration.ContainerName);
             Assert.NotEmpty(configuration.MessagePropertyToIdentifyAttachmentBlob);
             Assert.Equal(AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime.Days, configuration.SasTokenValidationTime.Value.Days);

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageEmulatorFixture.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageEmulatorFixture.cs
@@ -9,6 +9,8 @@
 
     public class AzureStorageEmulatorFixture
     {
+        public static IProvideStorageConnectionString ConnectionStringProvider = new PlainTextConnectionStringProvider("UseDevelopmentStorage=true");
+
         public AzureStorageEmulatorFixture()
         {
             AzureStorageEmulatorManager.StartStorageEmulator();

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_receiving_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_receiving_message.cs
@@ -28,8 +28,8 @@ namespace ServiceBus.AttachmentPlugin.Tests
                 connectionString: "UseDevelopmentStorage=true", containerName: "attachments-wrong-containers"));
 
             var exception = await Assert.ThrowsAsync<Exception>(() => receivingPlugin.AfterMessageReceive(message));
-            Assert.Contains("attachments-wrong-containers", exception.Message);
-            Assert.Contains(message.UserProperties["$attachment.blob"].ToString(), exception.Message);
+            Assert.Contains("attachments-wrong-containers", actualString: exception.Message);
+            Assert.Contains(message.UserProperties["$attachment.blob"].ToString(), actualString: exception.Message);
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_receiving_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_receiving_message.cs
@@ -9,7 +9,6 @@ namespace ServiceBus.AttachmentPlugin.Tests
 
     public class When_receiving_message : IClassFixture<AzureStorageEmulatorFixture>
     {
-
         [Fact]
         public async Task Should_throw_exception_with_blob_path_for_found_that_cant_be_found()
         {
@@ -21,11 +20,11 @@ namespace ServiceBus.AttachmentPlugin.Tests
             };
 
             var sendingPlugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments"));
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments"));
             await sendingPlugin.BeforeMessageSend(message);
 
             var receivingPlugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments-wrong-containers"));
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments-wrong-containers"));
 
             var exception = await Assert.ThrowsAsync<Exception>(() => receivingPlugin.AfterMessageReceive(message));
             Assert.Contains("attachments-wrong-containers", actualString: exception.Message);

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
@@ -19,7 +19,7 @@
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString:"UseDevelopmentStorage=true", containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
             var result = await plugin.BeforeMessageSend(message);
 
             Assert.Null(result.Body);
@@ -37,7 +37,7 @@
                 TimeToLive = TimeSpan.FromHours(1)
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString:"UseDevelopmentStorage=true", containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id",
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id",
                 messageMaxSizeReachedCriteria:msg => msg.Body.Length > 100));
             var result = await plugin.BeforeMessageSend(message);
 
@@ -56,13 +56,13 @@
                 TimeToLive = TimeSpan.FromHours(1)
             };
             var dateTimeNowUtc = new DateTime(2017, 1, 2);
-            var configuration = new AzureStorageAttachmentConfiguration(connectionString:"UseDevelopmentStorage=true", containerName:"attachments",
+            var configuration = new AzureStorageAttachmentConfiguration(connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments",
                 messagePropertyToIdentifyAttachmentBlob:"attachment-id");
             AzureStorageAttachment.DateTimeFunc = () => dateTimeNowUtc;
             var plugin = new AzureStorageAttachment(configuration);
             await plugin.BeforeMessageSend(message);
 
-            var account = CloudStorageAccount.Parse(configuration.ConnectionString);
+            var account = CloudStorageAccount.Parse(configuration.ConnectionStringProvider.GetConnectionString());
             var client = account.CreateCloudBlobClient();
             var container = client.GetContainerReference(configuration.ContainerName);
             var blobName = (string)message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];
@@ -79,7 +79,7 @@
             var bytes = Encoding.UTF8.GetBytes(payload);
             var message = new Message(bytes);
             var configuration = new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
 
             var plugin = new AzureStorageAttachment(configuration);
             await plugin.BeforeMessageSend(message);
@@ -101,7 +101,7 @@
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
             var result = await plugin.BeforeMessageSend(message);
 
             Assert.Null(result.Body);

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
@@ -62,7 +62,7 @@
             var plugin = new AzureStorageAttachment(configuration);
             await plugin.BeforeMessageSend(message);
 
-            var account = CloudStorageAccount.Parse(configuration.ConnectionStringProvider.GetConnectionString());
+            var account = CloudStorageAccount.Parse(await configuration.ConnectionStringProvider.GetConnectionString());
             var client = account.CreateCloudBlobClient();
             var container = client.GetContainerReference(configuration.ContainerName);
             var blobName = (string)message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -19,7 +19,7 @@
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionString: "UseDevelopmentStorage=true", containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id")
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id")
                 .WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(4), messagePropertyToIdentifySasUri: "mySasUriProperty"));
             var result = await plugin.BeforeMessageSend(message);
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_using_receive_only_plugin.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_using_receive_only_plugin.cs
@@ -20,7 +20,7 @@ namespace ServiceBus.AttachmentPlugin.Tests
                 MessageId = Guid.NewGuid().ToString(),
             };
             var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                    connectionString: "UseDevelopmentStorage=true", 
+                    connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, 
                     containerName: "attachments", 
                     messagePropertyToIdentifyAttachmentBlob: 
                     "attachment-id")

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -19,7 +19,7 @@
         public AzureStorageAttachment(AzureStorageAttachmentConfiguration configuration)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
-            var account = CloudStorageAccount.Parse(configuration.ConnectionString);
+            var account = CloudStorageAccount.Parse(configuration.ConnectionStringProvider.GetConnectionString());
             client = new Lazy<CloudBlobClient>(() => account.CreateCloudBlobClient());
             this.configuration = configuration;
         }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -19,7 +19,10 @@
         public AzureStorageAttachment(AzureStorageAttachmentConfiguration configuration)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
-            var account = CloudStorageAccount.Parse(configuration.ConnectionStringProvider.GetConnectionString());
+            // TODO: review this in next version to avoid .GetAwaiter().GetResult();
+            var connectionString = configuration.ConnectionStringProvider.GetConnectionString()
+                .GetAwaiter().GetResult();
+            var account = CloudStorageAccount.Parse(connectionString);
             client = new Lazy<CloudBlobClient>(() => account.CreateCloudBlobClient());
             this.configuration = configuration;
         }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -33,7 +33,7 @@
         {
             Guard.AgainstEmpty(nameof(containerName), containerName);
             Guard.AgainstEmpty(nameof(messagePropertyToIdentifyAttachmentBlob), messagePropertyToIdentifyAttachmentBlob);
-            ConnectionString = connectionStringProvider;
+            ConnectionStringProvider = connectionStringProvider;
             ContainerName = containerName;
             MessagePropertyToIdentifyAttachmentBlob = messagePropertyToIdentifyAttachmentBlob;
             MessageMaxSizeReachedCriteria = GetMessageMaxSizeReachedCriteria(messageMaxSizeReachedCriteria);
@@ -58,7 +58,7 @@
             };
         }
 
-        internal IProvideStorageConnectionString ConnectionString { get; }
+        internal IProvideStorageConnectionString ConnectionStringProvider { get; }
 
         internal string ContainerName { get; }
 

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -15,11 +15,25 @@
             string connectionString,
             string containerName = "attachments",
             string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            Func<Message, bool> messageMaxSizeReachedCriteria = null) 
+            : this(new PlainTextConnectionStringProvider(connectionString), containerName, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
+        {
+        }
+
+        /// <summary>Constructor to create new configuration object.</summary>
+        /// <param name="connectionStringProvider">Provider to retrieve connection string such as <see cref="PlainTextConnectionStringProvider"/></param>
+        /// <param name="containerName">Storage container name</param>
+        /// <param name="messagePropertyToIdentifyAttachmentBlob">Message user property to use for blob URI</param>
+        /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
+        public AzureStorageAttachmentConfiguration(
+            IProvideStorageConnectionString connectionStringProvider,
+            string containerName = "attachments",
+            string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
             Func<Message, bool> messageMaxSizeReachedCriteria = null)
         {
             Guard.AgainstEmpty(nameof(containerName), containerName);
             Guard.AgainstEmpty(nameof(messagePropertyToIdentifyAttachmentBlob), messagePropertyToIdentifyAttachmentBlob);
-            ConnectionString = connectionString;
+            ConnectionString = connectionStringProvider;
             ContainerName = containerName;
             MessagePropertyToIdentifyAttachmentBlob = messagePropertyToIdentifyAttachmentBlob;
             MessageMaxSizeReachedCriteria = GetMessageMaxSizeReachedCriteria(messageMaxSizeReachedCriteria);
@@ -44,7 +58,7 @@
             };
         }
 
-        internal string ConnectionString { get; }
+        internal IProvideStorageConnectionString ConnectionString { get; }
 
         internal string ContainerName { get; }
 

--- a/src/ServiceBus.AttachmentPlugin/Guard.cs
+++ b/src/ServiceBus.AttachmentPlugin/Guard.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace ServiceBus.AttachmentPlugin
+﻿namespace ServiceBus.AttachmentPlugin
 {
+    using System;
+
     static class Guard
     {
         public static void AgainstEmpty(string argumentName, string value)

--- a/src/ServiceBus.AttachmentPlugin/IProvideStorageConnectionString.cs
+++ b/src/ServiceBus.AttachmentPlugin/IProvideStorageConnectionString.cs
@@ -1,0 +1,13 @@
+﻿namespace ServiceBus.AttachmentPlugin
+{
+    /// <summary>
+    /// Storage account connection string provider.
+    /// </summary>
+    public interface IProvideStorageConnectionString
+    {
+        /// <summary>
+        /// Connection string for storage account to be used.
+        /// </summary>
+        string GetConnectionString();
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/IProvideStorageConnectionString.cs
+++ b/src/ServiceBus.AttachmentPlugin/IProvideStorageConnectionString.cs
@@ -1,5 +1,7 @@
 ﻿namespace ServiceBus.AttachmentPlugin
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Storage account connection string provider.
     /// </summary>
@@ -8,6 +10,6 @@
         /// <summary>
         /// Connection string for storage account to be used.
         /// </summary>
-        string GetConnectionString();
+        Task<string> GetConnectionString();
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/PlainTextConnectionStringProvider.cs
+++ b/src/ServiceBus.AttachmentPlugin/PlainTextConnectionStringProvider.cs
@@ -1,5 +1,7 @@
 ﻿namespace ServiceBus.AttachmentPlugin
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Static connection string provider.
     /// </summary>
@@ -17,9 +19,9 @@
         /// <summary>
         /// Return connection string for Storage account.
         /// </summary>
-        public string GetConnectionString()
+        public Task<string> GetConnectionString()
         {
-            return connectionString;
+            return Task.FromResult(connectionString);
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/PlainTextConnectionStringProvider.cs
+++ b/src/ServiceBus.AttachmentPlugin/PlainTextConnectionStringProvider.cs
@@ -1,0 +1,25 @@
+﻿namespace ServiceBus.AttachmentPlugin
+{
+    /// <summary>
+    /// Static connection string provider.
+    /// </summary>
+    public class PlainTextConnectionStringProvider : IProvideStorageConnectionString
+    {
+        readonly string connectionString;
+
+        /// <summary></summary>
+        /// <param name="connectionString">Storage connection string to use in plain text.</param>
+        public PlainTextConnectionStringProvider(string connectionString)
+        {
+            this.connectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Return connection string for Storage account.
+        /// </summary>
+        public string GetConnectionString()
+        {
+            return connectionString;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #30

Enables providers so that KeyVault could be used among other providers.

**Description** 
Add ability to register providers for connection strings. Providers would be separate nuget packages, such as KeyVault provider. Reason for separation is not to force coupling with KeyVault or any other nuget packages which can have their own dependencies. By doing so, a change in providers would not require a change of this package.