### PR TITLE
Idempotency feature

### DIFF
--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
@@ -92,6 +92,27 @@
         }
 
         [Fact]
+        public async Task Should_not_reupload_blob_if_one_is_already_assigned()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            var plugin = new AzureStorageAttachment(configuration);
+
+            var processedMessage = await plugin.BeforeMessageSend(message);
+
+            var blobId = processedMessage.UserProperties["attachment-id"];
+
+            var reprocessedMessage = await plugin.BeforeMessageSend(message);
+
+            Assert.Equal(blobId, reprocessedMessage.UserProperties["attachment-id"]);
+        }
+
+
+        [Fact]
         public async Task Should_not_set_sas_uri_by_default()
         {
             var payload = "payload";

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceBus.AttachmentPlugin
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
@@ -34,6 +35,11 @@
         {
             ThrowIfDisposed();
 
+            if (AttachmentBlobAssociated(message.UserProperties))
+            {
+                return message;
+            }
+
             if (!configuration.MessageMaxSizeReachedCriteria(message))
             {
                 return message;
@@ -62,6 +68,9 @@
             message.UserProperties[configuration.MessagePropertyForSasUri] = sasUri;
             return message;
         }
+
+        bool AttachmentBlobAssociated(IDictionary<string, object> messageUserProperties) => 
+            messageUserProperties.TryGetValue(configuration.MessagePropertyToIdentifyAttachmentBlob, out var _);
 
         async Task InitializeClient()
         {

--- a/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
+++ b/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft Azure ServiceBus attachment plugin</Description>
-    <Version>2.2.1</Version>
+    <Version>3.0.0-alpha0001</Version>
     <Authors>Sean Feldman</Authors>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic;Attachment;Plugin</PackageTags>


### PR DESCRIPTION
A message already containing `MessagePropertyToIdentifyAttachmentBlob` header will not be generating another attachment.