### PR TITLE
Fix for Container.CreateIfNotExist HTTP status 409

### DIFF
--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -48,7 +48,11 @@
             await InitializeClient().ConfigureAwait(false);
 
             var container = client.GetContainerReference(configuration.ContainerName);
-            await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+            
+            if (! await container.ExistsAsync())
+            {
+                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+            }
             var blob = container.GetBlockBlobReference(Guid.NewGuid().ToString());
 
             SetValidMessageId(blob, message.MessageId);
@@ -139,7 +143,11 @@
                 await InitializeClient().ConfigureAwait(false);
 
                 var container = client.GetContainerReference(configuration.ContainerName);
-                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+                
+                if (! await container.ExistsAsync())
+                {
+                    await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+                }
                 var blobName = (string)userProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];
                 blob = container.GetBlockBlobReference(blobName);
             }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -49,7 +49,7 @@
 
             var container = client.GetContainerReference(configuration.ContainerName);
             
-            if (! await container.ExistsAsync())
+            if (! await container.ExistsAsync().ConfigureAwait(false))
             {
                 await container.CreateIfNotExistsAsync().ConfigureAwait(false);
             }
@@ -144,7 +144,7 @@
 
                 var container = client.GetContainerReference(configuration.ContainerName);
                 
-                if (! await container.ExistsAsync())
+                if (! await container.ExistsAsync().ConfigureAwait(false))
                 {
                     await container.CreateIfNotExistsAsync().ConfigureAwait(false);
                 }


### PR DESCRIPTION
`CreateIfNotExists()` can fail with code 409 which represents more than one state ([similar to Tables](https://docs.microsoft.com/en-us/rest/api/storageservices/Table-Service-Error-Codes?))
- `TableAlreadyExists` or
- `TableBeingDeleted`

This is an [issue](https://github.com/Azure/azure-sdk-for-net/issues/109) with the Storage Table SDK with a [workaround](https://github.com/Azure/azure-sdk-for-net/issues/109#issuecomment-333512454) implemented in this PR.

**Original description**

Correcting an error in the storage client when CreateIfNotExists sometimes returns 409 status