### PR TITLE
change from null body to empty byte array

### DIFF
--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message.cs
@@ -22,7 +22,7 @@
                 connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
             var result = await plugin.BeforeMessageSend(message);
 
-            Assert.Null(result.Body);
+            Assert.Equal(new byte[0], result.Body);
             Assert.True(message.UserProperties.ContainsKey("attachment-id"));
         }
 
@@ -84,7 +84,7 @@
             var plugin = new AzureStorageAttachment(configuration);
             await plugin.BeforeMessageSend(message);
 
-            Assert.Null(message.Body);
+            Assert.Equal(new byte[0], message.Body);
 
             var receivedMessage = await plugin.AfterMessageReceive(message);
 
@@ -125,7 +125,7 @@
                 connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
             var result = await plugin.BeforeMessageSend(message);
 
-            Assert.Null(result.Body);
+            Assert.Equal(new byte[0], result.Body);
             Assert.True(message.UserProperties.ContainsKey("attachment-id"));
             Assert.False(message.UserProperties.ContainsKey("$attachment.sas.uri"));
         }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_sas_uri.cs
@@ -23,7 +23,7 @@
                 .WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(4), messagePropertyToIdentifySasUri: "mySasUriProperty"));
             var result = await plugin.BeforeMessageSend(message);
 
-            Assert.Null(result.Body);
+            Assert.Equal(new byte[0], result.Body);
             Assert.True(message.UserProperties.ContainsKey("attachment-id"));
             Assert.True(message.UserProperties.ContainsKey("mySasUriProperty"));
         }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -60,7 +60,7 @@
 
             await blob.UploadFromByteArrayAsync(message.Body,0, message.Body.Length).ConfigureAwait(false);
 
-            message.Body = null;
+            message.Body = new byte[0];
             message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob] = blob.Name;
 
             if (!configuration.SasTokenValidationTime.HasValue)

--- a/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
+++ b/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft Azure ServiceBus attachment plugin</Description>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>Sean Feldman</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic;Attachment;Plugin</PackageTags>


### PR DESCRIPTION
I'm making this PR in order to deal with certain versions of the azure webjobs sdk that deal poorly with with the null message body prior to delivering it to our code that handles the claim check.

Please let me know if there are other considerations I'm not aware of behind the decision to use a null body.