### PR TITLE
[WIP] Support for service SAS on container for writing and reading blobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,4 +287,4 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 /binaries
-/**/ApiApprovals.CompressionPlugin.received.txt
+/**/*.received.txt

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.ServiceBus
     public class AzureStorageAttachmentConfiguration
     {
         public AzureStorageAttachmentConfiguration(string connectionString, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool> messageMaxSizeReachedCriteria = null) { }
+        public AzureStorageAttachmentConfiguration(Microsoft.Azure.ServiceBus.SharedAccessSignature sharedAccessSignature, string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool> messageMaxSizeReachedCriteria = null) { }
         public AzureStorageAttachmentConfiguration(Microsoft.Azure.ServiceBus.IProvideStorageConnectionString connectionStringProvider, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool> messageMaxSizeReachedCriteria = null) { }
     }
     public class static AzureStorageAttachmentConfigurationExtensions
@@ -23,5 +24,11 @@ namespace Microsoft.Azure.ServiceBus
     {
         public PlainTextConnectionStringProvider(string connectionString) { }
         public System.Threading.Tasks.Task<string> GetConnectionString() { }
+    }
+    public class SharedAccessSignature
+    {
+        public SharedAccessSignature(string containerUri, string queryString) { }
+        public string ContainerUri { get; }
+        public string QueryString { get; }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -21,10 +21,11 @@
         }
 
         [Fact]
-        public void Should_not_accept_negative_token_validation_time()
-        {
-            Assert.Throws<ArgumentException>(() =>
-                new AzureStorageAttachmentConfiguration(new PlainTextConnectionStringProvider("connectionString")).WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(-4)));
-        }
+        public void Should_not_accept_negative_token_validation_time() =>
+            Assert.Throws<ArgumentException>(() => new AzureStorageAttachmentConfiguration(new PlainTextConnectionStringProvider("connectionString")).WithSasUri(sasTokenValidationTime: TimeSpan.FromHours(-4)));
+
+        [Fact]
+        public void Should_throw_when_embedded_SAS_option_is_used_with_container_SAS() =>
+            Assert.Throws<Exception>(() => new AzureStorageAttachmentConfiguration(new SharedAccessSignature("?qs")).WithSasUri());
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -26,6 +26,6 @@
 
         [Fact]
         public void Should_throw_when_embedded_SAS_option_is_used_with_container_SAS() =>
-            Assert.Throws<Exception>(() => new AzureStorageAttachmentConfiguration(new SharedAccessSignature("?qs")).WithSasUri());
+            Assert.Throws<Exception>(() => new AzureStorageAttachmentConfiguration(new SharedAccessSignature("https://container", "?qs")).WithSasUri());
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
@@ -26,15 +26,42 @@
         }
 
         [Fact]
-        public void Should_get_back_object_for_receive_only_plugin()
+        public void Should_get_back_AzureStorageAttachment_for_connection_string_based_configuration()
+        {
+            var client = new FakeClientEntity("fake", string.Empty, RetryPolicy.Default);
+
+            var azureStorageAttachmentConfiguration = new AzureStorageAttachmentConfiguration("connectionString");
+
+            var registeredPlugin = AzureStorageAttachmentExtensions.RegisterAzureStorageAttachmentPlugin(client, azureStorageAttachmentConfiguration);
+
+            Assert.Equal(registeredPlugin, client.RegisteredPlugins.First());
+            Assert.IsAssignableFrom<AzureStorageAttachment>(registeredPlugin);
+        }
+
+        [Fact]
+        public void Should_get_back_SasBasedAzureStorageAttachment_for_container_sas_based_configuration()
+        {
+            var client = new FakeClientEntity("fake", string.Empty, RetryPolicy.Default);
+
+            var azureStorageAttachmentConfiguration = new AzureStorageAttachmentConfiguration(new SharedAccessSignature("?qs"));
+
+            var registeredPlugin = AzureStorageAttachmentExtensions.RegisterAzureStorageAttachmentPlugin(client, azureStorageAttachmentConfiguration);
+
+            Assert.Equal(registeredPlugin, client.RegisteredPlugins.First());
+            Assert.IsAssignableFrom<SasBasedAzureStorageAttachment>(registeredPlugin);
+        }
+
+        [Fact]
+        public void Should_get_back_ReceiveOnlyAzureStorageAttachment_for_receive_only_plugin()
         {
             var client = new FakeClientEntity("fake", string.Empty, RetryPolicy.Default);
 
             var registeredPlugin = AzureStorageAttachmentExtensions.RegisterAzureStorageAttachmentPluginForReceivingOnly(client, "mySasUriProperty");
 
             Assert.Equal(registeredPlugin, client.RegisteredPlugins.First());
-            Assert.IsAssignableFrom<ServiceBusPlugin>(registeredPlugin);
+            Assert.IsAssignableFrom<ReceiveOnlyAzureStorageAttachment>(registeredPlugin);
         }
+
 
         class FakeClientEntity : ClientEntity
         {

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
@@ -62,7 +62,6 @@
             Assert.IsAssignableFrom<ReceiveOnlyAzureStorageAttachment>(registeredPlugin);
         }
 
-
         class FakeClientEntity : ClientEntity
         {
             public FakeClientEntity(string clientTypeName, string postfix, RetryPolicy retryPolicy) : base(clientTypeName, postfix, retryPolicy)

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_registering_plugin.cs
@@ -43,7 +43,7 @@
         {
             var client = new FakeClientEntity("fake", string.Empty, RetryPolicy.Default);
 
-            var azureStorageAttachmentConfiguration = new AzureStorageAttachmentConfiguration(new SharedAccessSignature("?qs"));
+            var azureStorageAttachmentConfiguration = new AzureStorageAttachmentConfiguration(new SharedAccessSignature("https://container", "?qs"));
 
             var registeredPlugin = AzureStorageAttachmentExtensions.RegisterAzureStorageAttachmentPlugin(client, azureStorageAttachmentConfiguration);
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_account_key.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_account_key.cs
@@ -7,7 +7,7 @@
     using Microsoft.WindowsAzure.Storage;
     using Xunit;
 
-    public class When_sending_message : IClassFixture<AzureStorageEmulatorFixture>
+    public class When_sending_message_using_account_key : IClassFixture<AzureStorageEmulatorFixture>
     {
         [Fact]
         public async Task Should_nullify_body_when_body_should_be_sent_as_attachment()

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_connection_string.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_connection_string.cs
@@ -1,0 +1,165 @@
+﻿namespace ServiceBus.AttachmentPlugin.Tests
+{
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.WindowsAzure.Storage;
+    using Xunit;
+
+    public class When_sending_message_using_connection_string : IClassFixture<AzureStorageEmulatorFixture>
+    {
+        readonly AzureStorageEmulatorFixture fixture;
+
+        public When_sending_message_using_connection_string(AzureStorageEmulatorFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Should_nullify_body_when_body_should_be_sent_as_attachment()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Null(result.Body);
+            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
+        }
+
+        [Fact]
+        public async Task Should_leave_body_as_is_for_message_not_exceeding_max_size()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+                TimeToLive = TimeSpan.FromHours(1)
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id",
+                messageMaxSizeReachedCriteria:msg => msg.Body.Length > 100));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.NotNull(result.Body);
+            Assert.False(message.UserProperties.ContainsKey("attachment-id"));
+        }
+
+        [Fact]
+        public async Task Should_set_valid_until_datetime_on_blob_same_as_message_TTL()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+                TimeToLive = TimeSpan.FromHours(1)
+            };
+            var dateTimeNowUtc = new DateTime(2017, 1, 2);
+            var configuration = new AzureStorageAttachmentConfiguration(connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments",
+                messagePropertyToIdentifyAttachmentBlob:"attachment-id");
+            AzureStorageAttachment.DateTimeFunc = () => dateTimeNowUtc;
+            var plugin = new AzureStorageAttachment(configuration);
+            await plugin.BeforeMessageSend(message);
+
+            var account = CloudStorageAccount.Parse(await configuration.ConnectionStringProvider.GetConnectionString());
+            var client = account.CreateCloudBlobClient();
+            var container = client.GetContainerReference(configuration.ContainerName);
+            var blobName = (string)message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];
+            var blob = container.GetBlockBlobReference(blobName);
+            await blob.FetchAttributesAsync();
+            var validUntil = blob.Metadata[AzureStorageAttachment.ValidUntilUtc];
+            Assert.Equal(dateTimeNowUtc.Add(message.TimeToLive).ToString(AzureStorageAttachment.DateFormat), validUntil);
+        }
+
+        [Fact]
+        public async Task Should_receive_it_using_connection_string()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            var plugin = new AzureStorageAttachment(configuration);
+            await plugin.BeforeMessageSend(message);
+
+            Assert.Null(message.Body);
+
+            var receivedMessage = await plugin.AfterMessageReceive(message);
+
+            Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
+        }
+
+        [Fact]
+        public async Task Should_not_reupload_blob_if_one_is_already_assigned()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            var plugin = new AzureStorageAttachment(configuration);
+
+            var processedMessage = await plugin.BeforeMessageSend(message);
+
+            var blobId = processedMessage.UserProperties["attachment-id"];
+
+            var reprocessedMessage = await plugin.BeforeMessageSend(message);
+
+            Assert.Equal(blobId, reprocessedMessage.UserProperties["attachment-id"]);
+        }
+
+
+        [Fact]
+        public async Task Should_not_set_sas_uri_by_default()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes)
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };
+            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id"));
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Null(result.Body);
+            Assert.True(message.UserProperties.ContainsKey("attachment-id"));
+            Assert.False(message.UserProperties.ContainsKey("$attachment.sas.uri"));
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_receive_using_container_sas()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            var plugin = new AzureStorageAttachment(configuration);
+            await plugin.BeforeMessageSend(message);
+
+            Assert.Null(message.Body);
+
+            var sas = new SharedAccessSignature(fixture.GetContainerUri("attachments"), await fixture.GetContainerSasQueryString("attachments"));
+            var receiveConfiguration = new AzureStorageAttachmentConfiguration(sas, messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            var receivePlugin = new SasBasedAzureStorageAttachment(receiveConfiguration);
+
+            var receivedMessage = await receivePlugin.AfterMessageReceive(message);
+
+            Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
+
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_connection_string.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_connection_string.cs
@@ -118,7 +118,6 @@
             Assert.Equal(blobId, reprocessedMessage.UserProperties["attachment-id"]);
         }
 
-
         [Fact]
         public async Task Should_not_set_sas_uri_by_default()
         {
@@ -159,7 +158,6 @@
             var receivedMessage = await receivePlugin.AfterMessageReceive(message);
 
             Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
-
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
@@ -9,6 +9,13 @@
 
     public class When_sending_message_using_container_sas : IClassFixture<AzureStorageEmulatorFixture>
     {
+        readonly AzureStorageEmulatorFixture fixture;
+
+        public When_sending_message_using_container_sas(AzureStorageEmulatorFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
         [Fact]
         public async Task Should_nullify_body_when_body_should_be_sent_as_attachment()
         {
@@ -18,8 +25,8 @@
             {
                 MessageId = Guid.NewGuid().ToString(),
             };
-            var plugin = new AzureStorageAttachment(new AzureStorageAttachmentConfiguration(
-                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName:"attachments", messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
+            var sas = new SharedAccessSignature(fixture.GetContainerUri("attachments"), await fixture.GetContainerSasQueryString("attachments"));
+            var plugin = new SasBasedAzureStorageAttachment(new AzureStorageAttachmentConfiguration(sas, messagePropertyToIdentifyAttachmentBlob:"attachment-id"));
             var result = await plugin.BeforeMessageSend(message);
 
             Assert.Null(result.Body);

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
@@ -118,7 +118,6 @@
             Assert.Equal(blobId, reprocessedMessage.UserProperties["attachment-id"]);
         }
 
-
         [Fact]
         public async Task Should_not_set_embedded_sas_uri_by_default()
         {

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_using_container_sas.cs
@@ -7,7 +7,7 @@
     using Microsoft.WindowsAzure.Storage;
     using Xunit;
 
-    public class When_sending_message_using_account_key : IClassFixture<AzureStorageEmulatorFixture>
+    public class When_sending_message_using_container_sas : IClassFixture<AzureStorageEmulatorFixture>
     {
         [Fact]
         public async Task Should_nullify_body_when_body_should_be_sent_as_attachment()
@@ -73,7 +73,7 @@
         }
 
         [Fact]
-        public async Task Should_receive_it()
+        public async Task Should_receive_it_using_container_sas()
         {
             var payload = "payload";
             var bytes = Encoding.UTF8.GetBytes(payload);
@@ -128,6 +128,12 @@
             Assert.Null(result.Body);
             Assert.True(message.UserProperties.ContainsKey("attachment-id"));
             Assert.False(message.UserProperties.ContainsKey("$attachment.sas.uri"));
+        }
+
+        [Fact]
+        public void Should_be_able_to_receive_using_storage_connection_string()
+        {
+            Assert.True(false, "not implemented yet");
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_embedded_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_embedded_sas_uri.cs
@@ -6,7 +6,7 @@
     using Microsoft.Azure.ServiceBus;
     using Xunit;
 
-    public class When_sending_message_with_sas_uri : IClassFixture<AzureStorageEmulatorFixture>
+    public class When_sending_message_with_embedded_sas_uri : IClassFixture<AzureStorageEmulatorFixture>
     {
 
         [Fact]

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_embedded_sas_uri.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_sending_message_with_embedded_sas_uri.cs
@@ -8,7 +8,6 @@
 
     public class When_sending_message_with_embedded_sas_uri : IClassFixture<AzureStorageEmulatorFixture>
     {
-
         [Fact]
         public async Task Should_set_sas_uri_when_specified()
         {

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -12,7 +12,7 @@
     class AzureStorageAttachment : ServiceBusPlugin, IDisposable
     {
         SemaphoreSlim semaphore= new SemaphoreSlim(1);
-        const string MessageId = "_MessageId";
+        internal const string MessageId = "_MessageId";
         internal const string ValidUntilUtc = "_ValidUntilUtc";
         internal const string DateFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
 

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -20,18 +20,17 @@
         }
 
         /// <summary>Constructor to create new configuration object.</summary>
+        /// <remarks>Container name is not required as it's included in the SharedAccessSignature.</remarks>
         /// <param name="sharedAccessSignature"></param>
-        /// <param name="containerName"></param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(
             SharedAccessSignature sharedAccessSignature,
-            string containerName = "attachments",
             string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
             Func<Message, bool> messageMaxSizeReachedCriteria = null)
-            : this(new PlainTextConnectionStringProvider(sharedAccessSignature.QueryString), containerName, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
+            : this(new PlainTextConnectionStringProvider(sharedAccessSignature.QueryString), null, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
         {
-            this.UsingContainerSas = true;
+            this.SharedAccessSignature = sharedAccessSignature;
         }
 
         /// <summary>Constructor to create new configuration object.</summary>
@@ -84,6 +83,8 @@
 
         internal Func<Message, bool> MessageMaxSizeReachedCriteria { get; }
 
-        internal bool UsingContainerSas { get; }
+        internal SharedAccessSignature SharedAccessSignature { get; }
+
+        internal bool UsingContainerSas => SharedAccessSignature != null;
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -20,6 +20,21 @@
         }
 
         /// <summary>Constructor to create new configuration object.</summary>
+        /// <param name="sharedAccessSignature"></param>
+        /// <param name="containerName"></param>
+        /// <param name="messagePropertyToIdentifyAttachmentBlob"></param>
+        /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
+        public AzureStorageAttachmentConfiguration(
+            SharedAccessSignature sharedAccessSignature,
+            string containerName = "attachments",
+            string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            Func<Message, bool> messageMaxSizeReachedCriteria = null)
+            : this(new PlainTextConnectionStringProvider(sharedAccessSignature.QueryString), containerName, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
+        {
+            this.UsingContainerSas = true;
+        }
+
+        /// <summary>Constructor to create new configuration object.</summary>
         /// <param name="connectionStringProvider">Provider to retrieve connection string such as <see cref="PlainTextConnectionStringProvider"/></param>
         /// <param name="containerName">Storage container name</param>
         /// <param name="messagePropertyToIdentifyAttachmentBlob">Message user property to use for blob URI</param>
@@ -68,5 +83,7 @@
         internal string MessagePropertyToIdentifyAttachmentBlob { get; }
 
         internal Func<Message, bool> MessageMaxSizeReachedCriteria { get; }
+
+        internal bool UsingContainerSas { get; }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -22,6 +22,11 @@
             string messagePropertyToIdentifySasUri = DefaultMessagePropertyToIdentitySasUri,
             TimeSpan? sasTokenValidationTime = null)
         {
+            if (azureStorageAttachmentConfiguration.UsingContainerSas)
+            {
+                throw new Exception("Invalid configuration: .WithSasUri() requires account key and cannot be used with container Shared Access Signature.");
+            }
+
             if (sasTokenValidationTime == null)
             {
                 sasTokenValidationTime = DefaultSasTokenValidationTime;

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.Azure.ServiceBus
 {
+    using System.Threading.Tasks;
     using Core;
     using global::ServiceBus.AttachmentPlugin;
 
@@ -12,7 +13,16 @@
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
         public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this ClientEntity client, AzureStorageAttachmentConfiguration configuration)
         {
-            ServiceBusPlugin plugin = new AzureStorageAttachment(configuration);
+            ServiceBusPlugin plugin;
+
+            if (!configuration.UsingContainerSas)
+            {
+                plugin = new AzureStorageAttachment(configuration);
+            }
+            else
+            {
+                plugin = new SasBasedAzureStorageAttachment(configuration);
+            }
 
             client.RegisterPlugin(plugin);
 
@@ -30,6 +40,32 @@
             client.RegisterPlugin(plugin);
 
             return plugin;
+        }
+    }
+
+    internal class SasBasedAzureStorageAttachment : ServiceBusPlugin
+    {
+        readonly AzureStorageAttachmentConfiguration configuration;
+
+        public SasBasedAzureStorageAttachment(AzureStorageAttachmentConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        // TODO: should the name be the same name for all permutations? looks like a bug
+        public override string Name => nameof(SasBasedAzureStorageAttachment);
+
+        // TODO: need to review this. looks like a bug. If plugin is failing, should throw.
+        //public override bool ShouldContinueOnException { get; }
+
+        public override Task<Message> BeforeMessageSend(Message message)
+        {
+            return base.BeforeMessageSend(message);
+        }
+
+        public override Task<Message> AfterMessageReceive(Message message)
+        {
+            return base.AfterMessageReceive(message);
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.Azure.ServiceBus
 {
-    using System.Threading.Tasks;
     using Core;
     using global::ServiceBus.AttachmentPlugin;
 
@@ -40,32 +39,6 @@
             client.RegisterPlugin(plugin);
 
             return plugin;
-        }
-    }
-
-    internal class SasBasedAzureStorageAttachment : ServiceBusPlugin
-    {
-        readonly AzureStorageAttachmentConfiguration configuration;
-
-        public SasBasedAzureStorageAttachment(AzureStorageAttachmentConfiguration configuration)
-        {
-            this.configuration = configuration;
-        }
-
-        // TODO: should the name be the same name for all permutations? looks like a bug
-        public override string Name => nameof(SasBasedAzureStorageAttachment);
-
-        // TODO: need to review this. looks like a bug. If plugin is failing, should throw.
-        //public override bool ShouldContinueOnException { get; }
-
-        public override Task<Message> BeforeMessageSend(Message message)
-        {
-            return base.BeforeMessageSend(message);
-        }
-
-        public override Task<Message> AfterMessageReceive(Message message)
-        {
-            return base.AfterMessageReceive(message);
         }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -1,0 +1,130 @@
+﻿namespace Microsoft.Azure.ServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading.Tasks;
+    using WindowsAzure.Storage;
+    using WindowsAzure.Storage.Blob;
+    using Core;
+    using global::ServiceBus.AttachmentPlugin;
+
+    class SasBasedAzureStorageAttachment : ServiceBusPlugin
+    {
+        readonly AzureStorageAttachmentConfiguration configuration;
+
+        public SasBasedAzureStorageAttachment(AzureStorageAttachmentConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        // TODO: should the name be the same name for all permutations? looks like a bug
+        // https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/issues/76
+        public override string Name => nameof(SasBasedAzureStorageAttachment);
+
+        // TODO: need to review this. looks like a bug. If plugin is failing, should throw.
+        // https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/issues/75
+        //public override bool ShouldContinueOnException { get; }
+
+        public override async Task<Message> BeforeMessageSend(Message message)
+        {
+            if (AttachmentBlobAssociated(message.UserProperties))
+            {
+                return message;
+            }
+
+            if (!configuration.MessageMaxSizeReachedCriteria(message))
+            {
+                return message;
+            }
+
+            var blobName = Guid.NewGuid().ToString();
+            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}?{configuration.SharedAccessSignature.QueryString}");
+            var blob = new CloudBlockBlob(uri);
+
+            SetValidMessageId(blob, message.MessageId);
+            SetValidUntil(blob, message.TimeToLive);
+
+            await blob.UploadFromByteArrayAsync(message.Body, 0, message.Body.Length).ConfigureAwait(false);
+
+            message.Body = null;
+            message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob] = blob.Name;
+
+            if (!configuration.SasTokenValidationTime.HasValue)
+            {
+                return message;
+            }
+
+            var sasUri = TokenGenerator.GetBlobSasUri(blob, configuration.SasTokenValidationTime.Value);
+            message.UserProperties[configuration.MessagePropertyForSasUri] = sasUri;
+            return message;
+        }
+
+        // TODO: duplicated from AzureStorageAttachment
+        bool AttachmentBlobAssociated(IDictionary<string, object> messageUserProperties) =>
+            messageUserProperties.TryGetValue(configuration.MessagePropertyToIdentifyAttachmentBlob, out var _);
+
+        // TODO: duplicated from AzureStorageAttachment
+        static void SetValidMessageId(ICloudBlob blob, string messageId)
+        {
+            if (!string.IsNullOrWhiteSpace(messageId))
+            {
+                blob.Metadata[AzureStorageAttachment.MessageId] = messageId;
+            }
+        }
+
+        // TODO: duplicated from AzureStorageAttachment
+        static void SetValidUntil(ICloudBlob blob, TimeSpan timeToBeReceived)
+        {
+            if (timeToBeReceived == TimeSpan.MaxValue)
+            {
+                return;
+            }
+
+            var validUntil = DateTimeFunc().Add(timeToBeReceived);
+            blob.Metadata[AzureStorageAttachment.ValidUntilUtc] = validUntil.ToString(AzureStorageAttachment.DateFormat);
+        }
+
+        // TODO: duplicated from AzureStorageAttachment
+        internal static Func<DateTime> DateTimeFunc = () => DateTime.UtcNow;
+
+        public override async Task<Message> AfterMessageReceive(Message message)
+        {
+            var userProperties = message.UserProperties;
+
+            if (!userProperties.ContainsKey(configuration.MessagePropertyToIdentifyAttachmentBlob))
+            {
+                return message;
+            }
+
+            var blobName = (string)userProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];
+            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}?{configuration.SharedAccessSignature.QueryString}");
+            var blob = new CloudBlockBlob(uri);
+
+            try
+            {
+                await blob.FetchAttributesAsync().ConfigureAwait(false);
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Forbidden)
+                {
+                    Console.WriteLine("forbidden");
+                }
+                Console.WriteLine(exception.RequestInformation.ExtendedErrorInformation.ErrorCode);
+                Console.WriteLine(exception.Message);
+
+                // TODO: different exception is needed here - the sas uri should be reported back
+                throw new Exception($"Blob with name '{blob.Name}' under container '{blob.Container.Name}' cannot be found."
+                    + $" Check {nameof(AzureStorageAttachmentConfiguration)}.{nameof(AzureStorageAttachmentConfiguration.ContainerName)} or"
+                    + $" {nameof(AzureStorageAttachmentConfiguration)}.{nameof(AzureStorageAttachmentConfiguration.MessagePropertyToIdentifyAttachmentBlob)} for correct values.", exception);
+            }
+            var fileByteLength = blob.Properties.Length;
+            var bytes = new byte[fileByteLength];
+            await blob.DownloadToByteArrayAsync(bytes, 0).ConfigureAwait(false);
+            message.Body = bytes;
+
+            return message;
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -101,12 +101,12 @@
             catch (StorageException exception)
             {
                 // TODO: should Forbidden be handled differently?
-//                if (exception.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Forbidden)
-//                {
-//                    Console.WriteLine("forbidden");
-//                }
-//                Console.WriteLine(exception.RequestInformation.ExtendedErrorInformation.ErrorCode);
-//                Console.WriteLine(exception.Message);
+                if (exception.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.Forbidden)
+                {
+                    Console.WriteLine("forbidden");
+                }
+                Console.WriteLine(exception.RequestInformation?.ExtendedErrorInformation?.ErrorCode);
+                Console.WriteLine(exception.Message);
 
                 // TODO: different exception is needed here - the sas uri should be reported back
                 throw new Exception($"Blob with name '{blob.Name}' under container '{blob.Container.Name}' cannot be found."

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -100,12 +100,13 @@
             }
             catch (StorageException exception)
             {
-                if (exception.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Forbidden)
-                {
-                    Console.WriteLine("forbidden");
-                }
-                Console.WriteLine(exception.RequestInformation.ExtendedErrorInformation.ErrorCode);
-                Console.WriteLine(exception.Message);
+                // TODO: should Forbidden be handled differently?
+//                if (exception.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Forbidden)
+//                {
+//                    Console.WriteLine("forbidden");
+//                }
+//                Console.WriteLine(exception.RequestInformation.ExtendedErrorInformation.ErrorCode);
+//                Console.WriteLine(exception.Message);
 
                 // TODO: different exception is needed here - the sas uri should be reported back
                 throw new Exception($"Blob with name '{blob.Name}' under container '{blob.Container.Name}' cannot be found."

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -98,7 +98,7 @@
             }
 
             var blobName = (string)userProperties[configuration.MessagePropertyToIdentifyAttachmentBlob];
-            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}?{configuration.SharedAccessSignature.QueryString}");
+            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}{configuration.SharedAccessSignature.QueryString}");
             var blob = new CloudBlockBlob(uri);
 
             try

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -39,7 +39,7 @@
             }
 
             var blobName = Guid.NewGuid().ToString();
-            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}?{configuration.SharedAccessSignature.QueryString}");
+            var uri = new Uri($"{configuration.SharedAccessSignature.ContainerUri}/{blobName}{configuration.SharedAccessSignature.QueryString}");
             var blob = new CloudBlockBlob(uri);
 
             SetValidMessageId(blob, message.MessageId);

--- a/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/SasBasedAzureStorageAttachment.cs
@@ -50,13 +50,6 @@
             message.Body = null;
             message.UserProperties[configuration.MessagePropertyToIdentifyAttachmentBlob] = blob.Name;
 
-            if (!configuration.SasTokenValidationTime.HasValue)
-            {
-                return message;
-            }
-
-            var sasUri = TokenGenerator.GetBlobSasUri(blob, configuration.SasTokenValidationTime.Value);
-            message.UserProperties[configuration.MessagePropertyForSasUri] = sasUri;
             return message;
         }
 

--- a/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
+++ b/src/ServiceBus.AttachmentPlugin/ServiceBus.AttachmentPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft Azure ServiceBus attachment plugin</Description>
-    <Version>4.0.0</Version>
+    <Version>4.1.0-preview-001</Version>
     <Authors>Sean Feldman</Authors>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic;Attachment;Plugin</PackageTags>

--- a/src/ServiceBus.AttachmentPlugin/SharedAccessSignature.cs
+++ b/src/ServiceBus.AttachmentPlugin/SharedAccessSignature.cs
@@ -1,0 +1,25 @@
+﻿namespace Microsoft.Azure.ServiceBus
+{
+    /// <summary>
+    /// Shared Access Signature
+    /// </summary>
+    public class SharedAccessSignature
+    {
+        /// <summary>
+        /// Query String representation of SAS
+        /// </summary>
+        public string QueryString { get; }
+
+        /// <summary>
+        /// Construct a new SAS using SAS query string only.
+        /// <remarks>Query string can include Stored Access Policy.</remarks>
+        /// </summary>
+        /// <param name="queryString"></param>
+        public SharedAccessSignature(string queryString)
+        {
+            Guard.AgainstEmpty(nameof(queryString), queryString);
+
+            QueryString = queryString;
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/SharedAccessSignature.cs
+++ b/src/ServiceBus.AttachmentPlugin/SharedAccessSignature.cs
@@ -6,6 +6,11 @@
     public class SharedAccessSignature
     {
         /// <summary>
+        /// Container URI w/o query string.
+        /// </summary>
+        public string ContainerUri { get; }
+
+        /// <summary>
         /// Query String representation of SAS
         /// </summary>
         public string QueryString { get; }
@@ -14,11 +19,14 @@
         /// Construct a new SAS using SAS query string only.
         /// <remarks>Query string can include Stored Access Policy.</remarks>
         /// </summary>
+        /// <param name="containerUri"></param>
         /// <param name="queryString"></param>
-        public SharedAccessSignature(string queryString)
+        public SharedAccessSignature(string containerUri, string queryString)
         {
+            Guard.AgainstEmpty(nameof(containerUri), containerUri);
             Guard.AgainstEmpty(nameof(queryString), queryString);
 
+            ContainerUri = containerUri;
             QueryString = queryString;
         }
     }


### PR DESCRIPTION
Fixes #74 

- Eliminate the need to expose connection string with account key by adding the ability to configure the plugin to use SAS (container URI + SAS connection string).
- Also works with Stored Access Policies.
- Allow authentication permutations (sender/receiver) as described in https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/issues/74#issuecomment-450444207

