### PR TITLE
Support for Azure Functions

### DIFF
--- a/README.source.md
+++ b/README.source.md
@@ -91,6 +91,19 @@ snippet: Configuring_plugin_using_StorageCredentials
 
 See [`StorageCredentials`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.windowsazure.storage.auth.storagecredentials) for more details.
 
+### Using attachments with Azure Functions
+
+Azure Functions currently has no way to register plugins, these extension methods are a workaround until this feature is added. 
+
+To use the extensions, your Function must return (send) or take as parameter (receive) an instance of [`Message`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message).
+
+Upload attachment to Azure Storage blob
+
+snippet: Upload_attachment_without_registering_plugin
+
+Download attachment from Azure Storage blob
+
+snippet: Download_attachment_without_registering_plugin
 
 #### Additional providers
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -26,8 +26,7 @@ namespace Microsoft.Azure.ServiceBus
     public class static MessageExtensions
     {
         public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
-        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message) { }
-        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, string messagePropertyToIdentifySasUri) { }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
         public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> UploadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
     }
     public class PlainTextConnectionStringProvider : Microsoft.Azure.ServiceBus.IProvideStorageConnectionString

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -23,6 +23,11 @@ namespace Microsoft.Azure.ServiceBus
     {
         System.Threading.Tasks.Task<string> GetConnectionString();
     }
+    public class static MessageExtensions
+    {
+        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> UploadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+    }
     public class PlainTextConnectionStringProvider : Microsoft.Azure.ServiceBus.IProvideStorageConnectionString
     {
         public PlainTextConnectionStringProvider(string connectionString) { }

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.ServiceBus
     public class static MessageExtensions
     {
         public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message) { }
+        public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> DownloadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, string messagePropertyToIdentifySasUri) { }
         public static System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> UploadAzureStorageAttachment(this Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
     }
     public class PlainTextConnectionStringProvider : Microsoft.Azure.ServiceBus.IProvideStorageConnectionString

--- a/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
@@ -118,6 +118,31 @@ class Snippets
         #endregion
     }
 
+    async Task Upload_attachment_without_registering_plugin(Message message, AzureStorageAttachmentConfiguration config)
+    {
+        #region Upload_attachment_without_registering_plugin
+
+        //To make it possible to use SAS URI when downloading, use WithBlobSasUri() when creating configuration object
+        await message.UploadAzureStorageAttachment(config);
+
+        #endregion
+    }
+    async Task Download_attachment_without_registering_plugin(Message message, AzureStorageAttachmentConfiguration config)
+    {
+        #region Download_attachment_without_registering_plugin
+
+        //Using SAS URI with default message property ($attachment.sas.uri)
+        await message.DownloadAzureStorageAttachment();
+
+        //Using SAS URI with custom message property 
+        await message.DownloadAzureStorageAttachment("$custom-attachment.sas.uri");
+        
+        //Using configuration object
+        await message.DownloadAzureStorageAttachment(config);
+
+        #endregion
+    }
+
     class MyMessage
     {
         public string MyProperty { get; set; }

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_using_message_extensions.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_using_message_extensions.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceBus.AttachmentPlugin.Tests
+{
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Xunit;
+
+    public class When_using_message_extensions : IClassFixture<AzureStorageEmulatorFixture>
+    {
+        readonly AzureStorageEmulatorFixture fixture;
+
+        public When_using_message_extensions(AzureStorageEmulatorFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Should_send_and_receive()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id");
+
+            await message.UploadAzureStorageAttachment(configuration);
+
+            Assert.Null(message.Body);
+
+            var receivedMessage = await message.DownloadAzureStorageAttachment(configuration);
+
+            Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin.Tests/When_using_message_extensions.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/When_using_message_extensions.cs
@@ -15,7 +15,7 @@
         }
 
         [Fact]
-        public async Task Should_send_and_receive()
+        public async Task Should_send_and_receive_with_configuration()
         {
             var payload = "payload";
             var bytes = Encoding.UTF8.GetBytes(payload);
@@ -28,6 +28,45 @@
             Assert.Null(message.Body);
 
             var receivedMessage = await message.DownloadAzureStorageAttachment(configuration);
+
+            Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
+        }
+
+        [Fact]
+        public async Task Should_send_and_receive_with_default_sas_uri_property()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id")
+            .WithBlobSasUri();
+
+            await message.UploadAzureStorageAttachment(configuration);
+
+            Assert.Null(message.Body);
+
+            var receivedMessage = await message.DownloadAzureStorageAttachment();
+
+            Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
+        }
+
+        [Fact]
+        public async Task Should_send_and_receive_with_custom_sas_uri_property()
+        {
+            var payload = "payload";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var message = new Message(bytes);
+            string customSasUri = "$custom-attachment.sas.uri";
+            var configuration = new AzureStorageAttachmentConfiguration(
+                connectionStringProvider: AzureStorageEmulatorFixture.ConnectionStringProvider, containerName: "attachments", messagePropertyToIdentifyAttachmentBlob: "attachment-id")
+            .WithBlobSasUri(customSasUri);
+
+            await message.UploadAzureStorageAttachment(configuration);
+
+            Assert.Null(message.Body);
+
+            var receivedMessage = await message.DownloadAzureStorageAttachment(customSasUri);
 
             Assert.Equal(payload, Encoding.UTF8.GetString(receivedMessage.Body));
         }

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -36,3 +36,4 @@
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
         }
     }
+}

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.Azure.ServiceBus
+{
+    using global::ServiceBus.AttachmentPlugin;
+    using System.Threading.Tasks;
+
+    /// <summary>Extension methods for working with attachments without registering plugin.</summary>
+    public static class MessageExtensions
+    {
+        /// <summary>Upload attachment to Azure Storage blob without registering plugin.</summary>
+        /// <param name="message"><see cref="Message"/></param>
+        /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
+        /// <returns><see cref="Message"/> with body uploaded to Azure Storage blob.</returns>
+        public static async Task<Message> UploadAzureStorageAttachment(this Message message, AzureStorageAttachmentConfiguration configuration)
+        {
+            var plugin = new AzureStorageAttachment(configuration);
+            return await plugin.BeforeMessageSend(message).ConfigureAwait(false);
+        }
+
+        /// <summary>Download attachment from Azure Storage blob without registering plugin.</summary>
+        /// <param name="message"><see cref="Message"/></param>
+        /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
+        /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
+        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, AzureStorageAttachmentConfiguration configuration)
+        {
+            var plugin = new AzureStorageAttachment(configuration);
+            return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -16,13 +16,33 @@
             return await plugin.BeforeMessageSend(message).ConfigureAwait(false);
         }
 
-        /// <summary>Download attachment from Azure Storage blob without registering plugin.</summary>
+        /// <summary>Download attachment from Azure Storage blob without registering plugin, using configuration object.</summary>
         /// <param name="message"><see cref="Message"/></param>
         /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
         /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
         public static async Task<Message> DownloadAzureStorageAttachment(this Message message, AzureStorageAttachmentConfiguration configuration)
         {
             var plugin = new AzureStorageAttachment(configuration);
+            return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
+        }
+
+        /// <summary>Download attachment from Azure Storage blob without registering plugin, using default message property to identify SAS URI.</summary>
+        /// <param name="message"><see cref="Message"/></param>
+        /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
+        public static async Task<Message> DownloadAzureStorageAttachment(this Message message)
+        {
+            var plugin = new ReceiveOnlyAzureStorageAttachment(AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri);
+            return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
+        }
+
+
+        /// <summary>Download attachment from Azure Storage blob without registering plugin, with custom message property to identify SAS URI.</summary>
+        /// <param name="message"><see cref="Message"/></param>
+        /// <param name="messagePropertyToIdentifySasUri">Message property which contains the SAS URI used to fetch message body from blob.</param>
+        /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
+        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, string messagePropertyToIdentifySasUri)
+        {
+            var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
         }
     }

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -26,23 +26,13 @@
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
         }
 
-        /// <summary>Download attachment from Azure Storage blob without registering plugin, using default message property to identify SAS URI.</summary>
-        /// <param name="message"><see cref="Message"/></param>
-        /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
-        public static async Task<Message> DownloadAzureStorageAttachment(this Message message)
-        {
-            var plugin = new ReceiveOnlyAzureStorageAttachment(AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri);
-            return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
-        }
-
-        /// <summary>Download attachment from Azure Storage blob without registering plugin, with custom message property to identify SAS URI.</summary>
+        /// <summary>Download attachment from Azure Storage blob without registering plugin, using message property to identify SAS URI.</summary>
         /// <param name="message"><see cref="Message"/></param>
         /// <param name="messagePropertyToIdentifySasUri">Message property which contains the SAS URI used to fetch message body from blob.</param>
         /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
-        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, string messagePropertyToIdentifySasUri)
+        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
         {
             var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
         }
     }
-}

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -35,7 +35,6 @@
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);
         }
 
-
         /// <summary>Download attachment from Azure Storage blob without registering plugin, with custom message property to identify SAS URI.</summary>
         /// <param name="message"><see cref="Message"/></param>
         /// <param name="messagePropertyToIdentifySasUri">Message property which contains the SAS URI used to fetch message body from blob.</param>


### PR DESCRIPTION
Hi!

Great job with this plugin, really nice!

Like #31 i would like to use it with Azure Functions and it seems like adding plugin support [might take a while:](https://github.com/Azure/azure-functions-host/issues/2504)
> paulbatum commented on Nov 7, 2018 
> There are no updates for this. It is not tracked as a high priority issue at this time.

Therefore i added these extensions to Message as a temporary solution. Usage looks something like this:

**Sending**
 ```csharp 
var config = new AzureStorageAttachmentConfiguration(storageConnectionString);
var message = new Message(data);
return await message.UploadAzureStorageAttachment(config);
  ```

**Receiving**
 ```csharp 
await message.DownloadAzureStorageAttachment(config);
string body = System.Text.Encoding.UTF8.GetString(message.Body);
  ```
[Here](https://github.com/lfalck/AzureFunctionsServiceBusAttachment) is a full example with Azure functions sending and receiving from Service Bus.

What do you think?