### PR TITLE
Use client entity contract instead of implementation.

### DIFF
--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -16,7 +16,9 @@ namespace Microsoft.Azure.ServiceBus
     public class static AzureStorageAttachmentExtensions
     {
         public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.ClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.IClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
         public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.ClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.IClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
     }
     public interface IProvideStorageConnectionString
     {

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.ServiceBus
     }
     public class static AzureStorageAttachmentExtensions
     {
-        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.ClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
-        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.ClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.IClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.IClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
     }
     public interface IProvideStorageConnectionString
     {

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.ServiceBus
     }
     public class static AzureStorageAttachmentExtensions
     {
-        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.IClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
-        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.IClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this Microsoft.Azure.ServiceBus.ClientEntity client, Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration configuration) { }
+        public static Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this Microsoft.Azure.ServiceBus.ClientEntity client, string messagePropertyToIdentifySasUri = "$attachment.sas.uri") { }
     }
     public interface IProvideStorageConnectionString
     {

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -10,7 +10,7 @@
         /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
         /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
-        public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this IClientEntity client, AzureStorageAttachmentConfiguration configuration)
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this ClientEntity client, AzureStorageAttachmentConfiguration configuration)
         {
             var plugin = new AzureStorageAttachment(configuration);
 
@@ -23,7 +23,7 @@
         /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
         /// <param name="messagePropertyToIdentifySasUri">Message property name to be used to retrieve message SAS UI.</param>
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
-        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this IClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this ClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
         {
             var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
 

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -31,5 +31,31 @@
 
             return plugin;
         }
+
+        /// <summary>Instantiate plugin with the required configuration.</summary>
+        /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
+        /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
+        /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this IClientEntity client, AzureStorageAttachmentConfiguration configuration)
+        {
+            var plugin = new AzureStorageAttachment(configuration);
+
+            client.RegisterPlugin(plugin);
+
+            return plugin;
+        }
+
+        /// <summary>Initiate plugin for Receive-Only mode to retrieve attachments using SAS URI. </summary>
+        /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
+        /// <param name="messagePropertyToIdentifySasUri">Message property name to be used to retrieve message SAS UI.</param>
+        /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this IClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
+        {
+            var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
+
+            client.RegisterPlugin(plugin);
+
+            return plugin;
+        }
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -10,7 +10,7 @@
         /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
         /// <param name="configuration"><see cref="AzureStorageAttachmentConfiguration"/> object.</param>
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
-        public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this ClientEntity client, AzureStorageAttachmentConfiguration configuration)
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPlugin(this IClientEntity client, AzureStorageAttachmentConfiguration configuration)
         {
             var plugin = new AzureStorageAttachment(configuration);
 
@@ -23,7 +23,7 @@
         /// <param name="client"><see cref="QueueClient"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
         /// <param name="messagePropertyToIdentifySasUri">Message property name to be used to retrieve message SAS UI.</param>
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
-        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this ClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this IClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
         {
             var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
 


### PR DESCRIPTION
The plugin registrations methods are expecting "ClientEntity" concrete implementation.
This could be problem when consumers are referencing "IMessageSender, IMessageReceiver" cannot register the plugin.

This change updates extensions methods with "IClientEntity" to make extension method available to consumer referencing contract and concrete implementations.