### PR TITLE
Allow blob name overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To Install from the Nuget Package Manager Console
     * [Sending a message without exposing the storage account to receivers](#sending-a-message-without-exposing-the-storage-account-to-receivers)
     * [Configure blob container name](#configure-blob-container-name)
     * [Configure message property to identify attachment blob](#configure-message-property-to-identify-attachment-blob)
+    * [Configure custom blob name override](#configure-custom-blob-name-override)
     * [Configure message property for SAS uri to attachment blob](#configure-message-property-for-sas-uri-to-attachment-blob)
     * [Configure criteria for message max size identification](#configure-criteria-for-message-max-size-identification)
     * [Configuring connection string provider](#configuring-connection-string-provider)
@@ -40,9 +41,7 @@ To Install from the Nuget Package Manager Console
     * [Using attachments with Azure Functions](#using-attachments-with-azure-functions)
   * [Cleanup](#cleanup)
   * [Who's trusting this plugin in production](#whos-trusting-this-plugin-in-production)
-  * [Icon](#icon)
-<!-- endtoc -->
-
+  * [Icon](#icon)<!-- endtoc -->
 
 ## Examples
 
@@ -57,7 +56,7 @@ var sender = new MessageSender(connectionString, queueName);
 var config = new AzureStorageAttachmentConfiguration(storageConnectionString);
 sender.RegisterAzureStorageAttachmentPlugin(config);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L14-L20) / [anchor](#snippet-configurationandregistration)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L14-L20' title='File snippet `configurationandregistration` was extracted from'>snippet source</a> | <a href='#snippet-configurationandregistration' title='Navigate to start of snippet `configurationandregistration`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Sending
@@ -73,7 +72,7 @@ var serialized = JsonConvert.SerializeObject(payload);
 var payloadAsBytes = Encoding.UTF8.GetBytes(serialized);
 var message = new Message(payloadAsBytes);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L26-L36) / [anchor](#snippet-attachmentsending)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L26-L36' title='File snippet `attachmentsending` was extracted from'>snippet source</a> | <a href='#snippet-attachmentsending' title='Navigate to start of snippet `attachmentsending`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Receiving
@@ -86,7 +85,7 @@ receiver.RegisterAzureStorageAttachmentPlugin(config);
 var message = await receiver.ReceiveAsync().ConfigureAwait(false);
 // message will contain the original payload
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L42-L49) / [anchor](#snippet-attachmentreceiving)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L42-L49' title='File snippet `attachmentreceiving` was extracted from'>snippet source</a> | <a href='#snippet-attachmentreceiving' title='Navigate to start of snippet `attachmentreceiving`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Sending a message without exposing the storage account to receivers
@@ -103,7 +102,7 @@ var config = new AzureStorageAttachmentConfiguration(storageConnectionString)
         messagePropertyToIdentifySasUri: "mySasUriProperty");
 sender.RegisterAzureStorageAttachmentPlugin(config);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L54-L63) / [anchor](#snippet-configurationandregistrationsas)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L54-L63' title='File snippet `configurationandregistrationsas` was extracted from'>snippet source</a> | <a href='#snippet-configurationandregistrationsas' title='Navigate to start of snippet `configurationandregistrationsas`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Sending
@@ -119,7 +118,7 @@ var serialized = JsonConvert.SerializeObject(payload);
 var payloadAsBytes = Encoding.UTF8.GetBytes(serialized);
 var message = new Message(payloadAsBytes);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L69-L79) / [anchor](#snippet-attachmentsendingsas)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L86-L96' title='File snippet `attachmentsendingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentsendingsas' title='Navigate to start of snippet `attachmentsendingsas`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Receiving only mode (w/o Storage account credentials)
@@ -132,7 +131,7 @@ Receiving only mode (w/o Storage account credentials)
 messageReceiver.RegisterAzureStorageAttachmentPluginForReceivingOnly("mySasUriProperty");
 var message = await messageReceiver.ReceiveAsync().ConfigureAwait(false);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L85-L92) / [anchor](#snippet-attachmentreceivingsas)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L102-L109' title='File snippet `attachmentreceivingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentreceivingsas' title='Navigate to start of snippet `attachmentreceivingsas`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configure blob container name
@@ -150,6 +149,27 @@ Default blob identifier property name is "$attachment.blob".
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, messagePropertyToIdentifyAttachmentBlob: "myblob");
 ```
+
+### Configure custom blob name override
+
+Default blob name is a GUID.
+
+<!-- snippet: Configure_blob_name_override -->
+<a id='snippet-configure_blob_name_override'/></a>
+```cs
+var sender = new MessageSender(connectionString, queueName);
+var config = new AzureStorageAttachmentConfiguration(storageConnectionString)
+    .OverrideBlobName(message =>
+    {
+        var tenantId = message.UserProperties["tenantId"].ToString();
+        var blobName = $"{tenantId}/{message.MessageId}";
+        return blobName;
+    });
+sender.RegisterAzureStorageAttachmentPlugin(config);
+```
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L68-L80' title='File snippet `configure_blob_name_override` was extracted from'>snippet source</a> | <a href='#snippet-configure_blob_name_override' title='Navigate to start of snippet `configure_blob_name_override`'>anchor</a></sup>
+<!-- endsnippet -->
+
 
 ### Configure message property for SAS uri to attachment blob
 
@@ -170,7 +190,7 @@ Default is to convert any body to attachment.
 new AzureStorageAttachmentConfiguration(storageConnectionString,
     messageMaxSizeReachedCriteria: message => message.Body.Length > 200 * 1024);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L97-L103) / [anchor](#snippet-configure_criteria_for_message_max_size_identification)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L114-L120' title='File snippet `configure_criteria_for_message_max_size_identification` was extracted from'>snippet source</a> | <a href='#snippet-configure_criteria_for_message_max_size_identification' title='Navigate to start of snippet `configure_criteria_for_message_max_size_identification`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configuring connection string provider
@@ -184,7 +204,7 @@ The plugin comes with a `PlainTextConnectionStringProvider` and can be used in t
 var provider = new PlainTextConnectionStringProvider(connectionString);
 var config = new AzureStorageAttachmentConfiguration(provider);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L109-L114) / [anchor](#snippet-configuring_connection_string_provider)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L126-L131' title='File snippet `configuring_connection_string_provider` was extracted from'>snippet source</a> | <a href='#snippet-configuring_connection_string_provider' title='Navigate to start of snippet `configuring_connection_string_provider`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configuring plugin using StorageCredentials (Service or Container SAS)
@@ -195,10 +215,10 @@ var config = new AzureStorageAttachmentConfiguration(provider);
 var credentials = new StorageCredentials( /*Shared key OR Service SAS OR Container SAS*/);
 var config = new AzureStorageAttachmentConfiguration(credentials, blobEndpoint);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L120-L125) / [anchor](#snippet-configuring_plugin_using_storagecredentials)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L137-L142' title='File snippet `configuring_plugin_using_storagecredentials` was extracted from'>snippet source</a> | <a href='#snippet-configuring_plugin_using_storagecredentials' title='Navigate to start of snippet `configuring_plugin_using_storagecredentials`'>anchor</a></sup>
 <!-- endsnippet -->
 
-See [`StorageCredentials`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.auth.storagecredentials?) for more details.
+See [`StorageCredentials`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.auth.storagecredentials) for more details.
 
 ### Using attachments with Azure Functions
 
@@ -214,7 +234,7 @@ Upload attachment to Azure Storage blob
 //To make it possible to use SAS URI when downloading, use WithBlobSasUri() when creating configuration object
 await message.UploadAzureStorageAttachment(config);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L130-L135) / [anchor](#snippet-upload_attachment_without_registering_plugin)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L147-L152' title='File snippet `upload_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-upload_attachment_without_registering_plugin' title='Navigate to start of snippet `upload_attachment_without_registering_plugin`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Download attachment from Azure Storage blob
@@ -231,7 +251,7 @@ await message.DownloadAzureStorageAttachment("$custom-attachment.sas.uri");
 //Using configuration object
 await message.DownloadAzureStorageAttachment(config);
 ```
-<sup>[snippet source](/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L139-L150) / [anchor](#snippet-download_attachment_without_registering_plugin)</sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L156-L167' title='File snippet `download_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-download_attachment_without_registering_plugin' title='Navigate to start of snippet `download_attachment_without_registering_plugin`'>anchor</a></sup>
 <!-- endsnippet -->
 
 #### Additional providers

--- a/README.source.md
+++ b/README.source.md
@@ -66,6 +66,13 @@ Default blob identifier property name is "$attachment.blob".
 new AzureStorageAttachmentConfiguration(storageConnectionString, messagePropertyToIdentifyAttachmentBlob: "myblob");
 ```
 
+### Configure custom blob name override
+
+Default blob name is a GUID.
+
+snippet: Configure_blob_name_override
+
+
 ### Configure message property for SAS uri to attachment blob
 
 Default SAS uri property name is "$attachment.sas.uri".

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.ServiceBus
     }
     public static class AzureStorageAttachmentConfigurationExtensions
     {
+        public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBlobName(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, string> blobNameResolver) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration WithBlobSasUri(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, string messagePropertyToIdentifySasUri = "$attachment.sas.uri", System.TimeSpan? sasTokenValidationTime = default) { }
     }
     public static class AzureStorageAttachmentExtensions

--- a/src/ServiceBus.AttachmentPlugin.Tests/ServiceBus.AttachmentPlugin.Tests.csproj
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ServiceBus.AttachmentPlugin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <RootNamespace>ServiceBus.AttachmentPlugin.Tests</RootNamespace>
     <Optimize>false</Optimize>
     <SignAssembly>true</SignAssembly>

--- a/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
@@ -63,6 +63,23 @@ class Snippets
         #endregion
     }
 
+    void Configure_blob_name_override(string connectionString, string queueName, string storageConnectionString)
+    {
+        #region Configure_blob_name_override
+
+        var sender = new MessageSender(connectionString, queueName);
+        var config = new AzureStorageAttachmentConfiguration(storageConnectionString)
+            .OverrideBlobName(message =>
+            {
+                var tenantId = message.UserProperties["tenantId"].ToString();
+                var blobName = $"{tenantId}/{message.MessageId}";
+                return blobName;
+            });
+        sender.RegisterAzureStorageAttachmentPlugin(config);
+
+        #endregion
+    }
+
     [SuppressMessage("ReSharper", "UnusedVariable")]
     void AttachmentSendingSas()
     {

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -56,7 +56,8 @@
                 // swallow in case a container SAS is used
             }
 
-            var blobUri = new Uri($"{containerUri}/{Guid.NewGuid().ToString()}");
+            var blobName = configuration.BlobNameResolver(message);
+            var blobUri = new Uri($"{containerUri}/{blobName}");
             var blob = new CloudBlockBlob(blobUri, configuration.StorageCredentials);
 
             SetValidMessageId(blob, message.MessageId);
@@ -104,7 +105,7 @@
         public override async Task<Message> AfterMessageReceive(Message message)
         {
             var userProperties = message.UserProperties;
-            
+
             if (!userProperties.TryGetValue(configuration.MessagePropertyToIdentifyAttachmentBlob, out var blobNameObject))
             {
                 return message;

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -120,5 +120,7 @@
         internal bool UsingSas => StorageCredentials.IsSAS;
 
         internal Uri BlobEndpoint { get; }
+
+        internal Func<Message, string> BlobNameResolver { get; set; } = message => Guid.NewGuid().ToString();
     }
 }

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -39,5 +39,33 @@
             return azureStorageAttachmentConfiguration;
         }
 
+        /// <summary>
+        /// Allow attachment blob name overriding.
+        /// </summary>
+        /// <param name="azureStorageAttachmentConfiguration"></param>
+        /// <param name="blobNameResolver">A custom blob name resolver to override the default name set to a GUID.</param>
+        /// <returns></returns>
+        public static AzureStorageAttachmentConfiguration OverrideBlobName(
+            this AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration,
+            Func<Message, string> blobNameResolver)
+        {
+            Guard.AgainstNull(nameof(blobNameResolver), blobNameResolver);
+
+            azureStorageAttachmentConfiguration.BlobNameResolver = BlobNameResolver;
+
+            return azureStorageAttachmentConfiguration;
+
+            string BlobNameResolver(Message message)
+            {
+                try
+                {
+                    return blobNameResolver(message);
+                }
+                catch (Exception exception)
+                {
+                    throw new Exception("An exception occurred when executing the blobNameResolver delegate.", exception);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #178 
Replaces #179 

The approach taken here is to add an extension method w/o modifying `AzureStorageAttachmentConfiguration`. Blob name is not something that many users tend to override (so far there were no requests) and adding it as a parameter, event as an optional one, feels unnecessary. Instead, a specific extension method is added to achieve the same goal.

For the testing, having a single test to verify messages can be sent and received using a blob name override is enough.

Documentation updated to show the usage.