### PR TITLE
Public default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ var message = await messageReceiver.ReceiveAsync().ConfigureAwait(false);
 
 ### Configure blob container name
 
-Default container name is "attachments". The value is available via `AzureStorageAttachmentConfiguration.DefaultContainerName` constant.
+Default container name is "attachments". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultContainerName` constant.
 
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, containerName:"blobs");
@@ -144,7 +144,7 @@ new AzureStorageAttachmentConfiguration(storageConnectionString, containerName:"
 
 ### Configure message property to identify attachment blob
 
-Default blob identifier property name is "$attachment.blob". The value is available via `AzureStorageAttachmentConfiguration.DefaultMessagePropertyToIdentifyAttachmentBlob` constant.
+Default blob identifier property name is "$attachment.blob". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentifyAttachmentBlob` constant.
 
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, messagePropertyToIdentifyAttachmentBlob: "myblob");
@@ -173,9 +173,9 @@ sender.RegisterAzureStorageAttachmentPlugin(config);
 
 ### Configure message property for SAS uri to attachment blob
 
-Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri` constant.
+Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri` constant.
 
-Default SAS token validation time is 7 days. The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime` constant.
+Default SAS token validation time is 7 days.
 
 <!-- snippet: Configure_blob_sas_uri_override -->
 <a id='snippet-configure_blob_sas_uri_override'/></a>

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ var serialized = JsonConvert.SerializeObject(payload);
 var payloadAsBytes = Encoding.UTF8.GetBytes(serialized);
 var message = new Message(payloadAsBytes);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L99-L109' title='File snippet `attachmentsendingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentsendingsas' title='Navigate to start of snippet `attachmentsendingsas`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L111-L121' title='File snippet `attachmentsendingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentsendingsas' title='Navigate to start of snippet `attachmentsendingsas`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Receiving only mode (w/o Storage account credentials)
@@ -131,7 +131,7 @@ Receiving only mode (w/o Storage account credentials)
 messageReceiver.RegisterAzureStorageAttachmentPluginForReceivingOnly("mySasUriProperty");
 var message = await messageReceiver.ReceiveAsync().ConfigureAwait(false);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L115-L122' title='File snippet `attachmentreceivingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentreceivingsas' title='Navigate to start of snippet `attachmentreceivingsas`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L127-L134' title='File snippet `attachmentreceivingsas` was extracted from'>snippet source</a> | <a href='#snippet-attachmentreceivingsas' title='Navigate to start of snippet `attachmentreceivingsas`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configure blob container name
@@ -173,11 +173,20 @@ sender.RegisterAzureStorageAttachmentPlugin(config);
 
 ### Configure message property for SAS uri to attachment blob
 
-Default SAS uri property name is "$attachment.sas.uri".
+Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri` constant.
 
-```c#
-new AzureStorageAttachmentConfiguration(storageConnectionString).WithSasUri(messagePropertyToIdentifySasUri: "mySasUriProperty");
+Default SAS token validation time is 7 days. The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime` constant.
+
+<!-- snippet: Configure_blob_sas_uri_override -->
+<a id='snippet-configure_blob_sas_uri_override'/></a>
+```cs
+new AzureStorageAttachmentConfiguration(storageConnectionString)
+    .WithBlobSasUri(
+        messagePropertyToIdentifySasUri: "mySasUriProperty",
+        sasTokenValidationTime: TimeSpan.FromHours(12));
 ```
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L85-L92' title='File snippet `configure_blob_sas_uri_override` was extracted from'>snippet source</a> | <a href='#snippet-configure_blob_sas_uri_override' title='Navigate to start of snippet `configure_blob_sas_uri_override`'>anchor</a></sup>
+<!-- endsnippet -->
 
 ### Configure criteria for message max size identification
 
@@ -190,7 +199,7 @@ Default is to convert any body to attachment.
 new AzureStorageAttachmentConfiguration(storageConnectionString,
     messageMaxSizeReachedCriteria: message => message.Body.Length > 200 * 1024);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L127-L133' title='File snippet `configure_criteria_for_message_max_size_identification` was extracted from'>snippet source</a> | <a href='#snippet-configure_criteria_for_message_max_size_identification' title='Navigate to start of snippet `configure_criteria_for_message_max_size_identification`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L139-L145' title='File snippet `configure_criteria_for_message_max_size_identification` was extracted from'>snippet source</a> | <a href='#snippet-configure_criteria_for_message_max_size_identification' title='Navigate to start of snippet `configure_criteria_for_message_max_size_identification`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configuring connection string provider
@@ -204,7 +213,7 @@ The plugin comes with a `PlainTextConnectionStringProvider` and can be used in t
 var provider = new PlainTextConnectionStringProvider(connectionString);
 var config = new AzureStorageAttachmentConfiguration(provider);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L139-L144' title='File snippet `configuring_connection_string_provider` was extracted from'>snippet source</a> | <a href='#snippet-configuring_connection_string_provider' title='Navigate to start of snippet `configuring_connection_string_provider`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L151-L156' title='File snippet `configuring_connection_string_provider` was extracted from'>snippet source</a> | <a href='#snippet-configuring_connection_string_provider' title='Navigate to start of snippet `configuring_connection_string_provider`'>anchor</a></sup>
 <!-- endsnippet -->
 
 ### Configuring plugin using StorageCredentials (Service or Container SAS)
@@ -215,7 +224,7 @@ var config = new AzureStorageAttachmentConfiguration(provider);
 var credentials = new StorageCredentials( /*Shared key OR Service SAS OR Container SAS*/);
 var config = new AzureStorageAttachmentConfiguration(credentials, blobEndpoint);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L150-L155' title='File snippet `configuring_plugin_using_storagecredentials` was extracted from'>snippet source</a> | <a href='#snippet-configuring_plugin_using_storagecredentials' title='Navigate to start of snippet `configuring_plugin_using_storagecredentials`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L162-L167' title='File snippet `configuring_plugin_using_storagecredentials` was extracted from'>snippet source</a> | <a href='#snippet-configuring_plugin_using_storagecredentials' title='Navigate to start of snippet `configuring_plugin_using_storagecredentials`'>anchor</a></sup>
 <!-- endsnippet -->
 
 See [`StorageCredentials`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.auth.storagecredentials) for more details.
@@ -234,7 +243,7 @@ Upload attachment to Azure Storage blob
 //To make it possible to use SAS URI when downloading, use WithBlobSasUri() when creating configuration object
 await message.UploadAzureStorageAttachment(config);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L160-L165' title='File snippet `upload_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-upload_attachment_without_registering_plugin' title='Navigate to start of snippet `upload_attachment_without_registering_plugin`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L172-L177' title='File snippet `upload_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-upload_attachment_without_registering_plugin' title='Navigate to start of snippet `upload_attachment_without_registering_plugin`'>anchor</a></sup>
 <!-- endsnippet -->
 
 Download attachment from Azure Storage blob
@@ -251,7 +260,7 @@ await message.DownloadAzureStorageAttachment("$custom-attachment.sas.uri");
 //Using configuration object
 await message.DownloadAzureStorageAttachment(config);
 ```
-<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L169-L180' title='File snippet `download_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-download_attachment_without_registering_plugin' title='Navigate to start of snippet `download_attachment_without_registering_plugin`'>anchor</a></sup>
+<sup><a href='/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs#L181-L192' title='File snippet `download_attachment_without_registering_plugin` was extracted from'>snippet source</a> | <a href='#snippet-download_attachment_without_registering_plugin' title='Navigate to start of snippet `download_attachment_without_registering_plugin`'>anchor</a></sup>
 <!-- endsnippet -->
 
 #### Additional providers

--- a/README.source.md
+++ b/README.source.md
@@ -52,7 +52,7 @@ snippet: AttachmentReceivingSas
 
 ### Configure blob container name
 
-Default container name is "attachments". The value is available via `AzureStorageAttachmentConfiguration.DefaultContainerName` constant.
+Default container name is "attachments". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultContainerName` constant.
 
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, containerName:"blobs");
@@ -60,7 +60,7 @@ new AzureStorageAttachmentConfiguration(storageConnectionString, containerName:"
 
 ### Configure message property to identify attachment blob
 
-Default blob identifier property name is "$attachment.blob". The value is available via `AzureStorageAttachmentConfiguration.DefaultMessagePropertyToIdentifyAttachmentBlob` constant.
+Default blob identifier property name is "$attachment.blob". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentifyAttachmentBlob` constant.
 
 ```c#
 new AzureStorageAttachmentConfiguration(storageConnectionString, messagePropertyToIdentifyAttachmentBlob: "myblob");
@@ -75,9 +75,9 @@ snippet: Configure_blob_name_override
 
 ### Configure message property for SAS uri to attachment blob
 
-Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri` constant.
+Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri` constant.
 
-Default SAS token validation time is 7 days. The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime` constant.
+Default SAS token validation time is 7 days.
 
 snippet: Configure_blob_sas_uri_override
 

--- a/README.source.md
+++ b/README.source.md
@@ -75,11 +75,11 @@ snippet: Configure_blob_name_override
 
 ### Configure message property for SAS uri to attachment blob
 
-Default SAS uri property name is "$attachment.sas.uri".
+Default SAS uri property name is "$attachment.sas.uri". The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri` constant.
 
-```c#
-new AzureStorageAttachmentConfiguration(storageConnectionString).WithSasUri(messagePropertyToIdentifySasUri: "mySasUriProperty");
-```
+Default SAS token validation time is 7 days. The value is available via `AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime` constant.
+
+snippet: Configure_blob_sas_uri_override
 
 ### Configure criteria for message max size identification
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.ServiceBus
     public static class AzureStorageAttachmentConfigurationExtensions
     {
         public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
-        public static readonly System.TimeSpan DefaultSasTokenValidationTime;
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBlobName(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, string> blobNameResolver) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBody(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, byte[]> bodyReplacer) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration WithBlobSasUri(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, string messagePropertyToIdentifySasUri = "$attachment.sas.uri", System.TimeSpan? sasTokenValidationTime = default) { }

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -3,15 +3,18 @@ namespace Microsoft.Azure.ServiceBus
 {
     public class AzureStorageAttachmentConfiguration
     {
-        public const string DefaultContainerName = "attachments";
-        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
         public AzureStorageAttachmentConfiguration(Microsoft.Azure.ServiceBus.IProvideStorageConnectionString connectionStringProvider, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }
         public AzureStorageAttachmentConfiguration(string connectionString, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }
         public AzureStorageAttachmentConfiguration(Microsoft.Azure.Storage.Auth.StorageCredentials storageCredentials, string blobEndpoint, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }
     }
+    public static class AzureStorageAttachmentConfigurationConstants
+    {
+        public const string DefaultContainerName = "attachments";
+        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
+        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
+    }
     public static class AzureStorageAttachmentConfigurationExtensions
     {
-        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBlobName(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, string> blobNameResolver) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBody(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, byte[]> bodyReplacer) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration WithBlobSasUri(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, string messagePropertyToIdentifySasUri = "$attachment.sas.uri", System.TimeSpan? sasTokenValidationTime = default) { }

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -3,6 +3,8 @@ namespace Microsoft.Azure.ServiceBus
 {
     public class AzureStorageAttachmentConfiguration
     {
+        public const string DefaultContainerName = "attachments";
+        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
         public AzureStorageAttachmentConfiguration(Microsoft.Azure.ServiceBus.IProvideStorageConnectionString connectionStringProvider, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }
         public AzureStorageAttachmentConfiguration(string connectionString, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }
         public AzureStorageAttachmentConfiguration(Microsoft.Azure.Storage.Auth.StorageCredentials storageCredentials, string blobEndpoint, string containerName = "attachments", string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob", System.Func<Microsoft.Azure.ServiceBus.Message, bool>? messageMaxSizeReachedCriteria = null) { }

--- a/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
+++ b/src/ServiceBus.AttachmentPlugin.Tests/ApprovalFiles/ApiApprovals.AzureStorageAttachmentPlugin.approved.txt
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.ServiceBus
     }
     public static class AzureStorageAttachmentConfigurationExtensions
     {
+        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
+        public static readonly System.TimeSpan DefaultSasTokenValidationTime;
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBlobName(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, string> blobNameResolver) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration OverrideBody(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, System.Func<Microsoft.Azure.ServiceBus.Message, byte[]> bodyReplacer) { }
         public static Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration WithBlobSasUri(this Microsoft.Azure.ServiceBus.AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration, string messagePropertyToIdentifySasUri = "$attachment.sas.uri", System.TimeSpan? sasTokenValidationTime = default) { }

--- a/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/AzureStorageAttachmentConfigurationTests.cs
@@ -19,7 +19,7 @@
             Assert.NotEmpty(configuration.ContainerName);
             Assert.NotEmpty(configuration.MessagePropertyToIdentifyAttachmentBlob);
             Assert.Equal(AzureStorageAttachmentConfigurationExtensions.DefaultSasTokenValidationTime.Days, configuration.BlobSasTokenValidationTime!.Value.Days);
-            Assert.Equal(AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri, configuration.MessagePropertyForBlobSasUri);
+            Assert.Equal(AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri, configuration.MessagePropertyForBlobSasUri);
             Assert.True(configuration.MessageMaxSizeReachedCriteria(new Message()));
         }
 

--- a/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
+++ b/src/ServiceBus.AttachmentPlugin.Tests/Snippets.cs
@@ -80,6 +80,18 @@ class Snippets
         #endregion
     }
 
+    void Configure_blob_sas_uri_override(string storageConnectionString)
+    {
+        #region Configure_blob_sas_uri_override
+
+        new AzureStorageAttachmentConfiguration(storageConnectionString)
+            .WithBlobSasUri(
+                messagePropertyToIdentifySasUri: "mySasUriProperty",
+                sasTokenValidationTime: TimeSpan.FromHours(12));
+
+        #endregion
+    }
+
     void Configure_body_override(string connectionString, string queueName, string storageConnectionString)
     {
         #region Configure_body_override

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -7,16 +7,6 @@
     /// <summary>Runtime configuration for Azure Storage Attachment plugin.</summary>
     public class AzureStorageAttachmentConfiguration
     {
-        /// <summary>
-        /// Default storage container name
-        /// </summary>
-        public const string DefaultContainerName = "attachments";
-
-        /// <summary>
-        /// Default message user property to use for blob URI
-        /// </summary>
-        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
-
         /// <summary>Constructor to create new configuration object.</summary>
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
@@ -24,8 +14,8 @@
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(
             string connectionString,
-            string containerName = DefaultContainerName,
-            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
+            string containerName = AzureStorageAttachmentConfigurationConstants.DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
             : this(new PlainTextConnectionStringProvider(connectionString), containerName, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
         {
@@ -41,8 +31,8 @@
         public AzureStorageAttachmentConfiguration(
             StorageCredentials storageCredentials,
             string blobEndpoint,
-            string containerName = DefaultContainerName,
-            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
+            string containerName = AzureStorageAttachmentConfigurationConstants.DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
         {
             Guard.AgainstNull(nameof(storageCredentials), storageCredentials);
@@ -75,8 +65,8 @@
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(
             IProvideStorageConnectionString connectionStringProvider,
-            string containerName = DefaultContainerName,
-            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
+            string containerName = AzureStorageAttachmentConfigurationConstants.DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
         {
             Guard.AgainstNull(nameof(connectionStringProvider), connectionStringProvider);

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfiguration.cs
@@ -7,6 +7,16 @@
     /// <summary>Runtime configuration for Azure Storage Attachment plugin.</summary>
     public class AzureStorageAttachmentConfiguration
     {
+        /// <summary>
+        /// Default storage container name
+        /// </summary>
+        public const string DefaultContainerName = "attachments";
+
+        /// <summary>
+        /// Default message user property to use for blob URI
+        /// </summary>
+        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
+
         /// <summary>Constructor to create new configuration object.</summary>
         /// <param name="connectionString"></param>
         /// <param name="containerName"></param>
@@ -14,8 +24,8 @@
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(
             string connectionString,
-            string containerName = "attachments",
-            string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            string containerName = DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
             : this(new PlainTextConnectionStringProvider(connectionString), containerName, messagePropertyToIdentifyAttachmentBlob, messageMaxSizeReachedCriteria)
         {
@@ -31,8 +41,8 @@
         public AzureStorageAttachmentConfiguration(
             StorageCredentials storageCredentials,
             string blobEndpoint,
-            string containerName = "attachments",
-            string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            string containerName = DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
         {
             Guard.AgainstNull(nameof(storageCredentials), storageCredentials);
@@ -65,8 +75,8 @@
         /// <param name="messageMaxSizeReachedCriteria">Default is always use attachments</param>
         public AzureStorageAttachmentConfiguration(
             IProvideStorageConnectionString connectionStringProvider,
-            string containerName = "attachments",
-            string messagePropertyToIdentifyAttachmentBlob = "$attachment.blob",
+            string containerName = DefaultContainerName,
+            string messagePropertyToIdentifyAttachmentBlob = DefaultMessagePropertyToIdentifyAttachmentBlob,
             Func<Message, bool>? messageMaxSizeReachedCriteria = default)
         {
             Guard.AgainstNull(nameof(connectionStringProvider), connectionStringProvider);

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationConstants.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationConstants.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Azure.ServiceBus
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class AzureStorageAttachmentConfigurationConstants
+    {
+        /// <summary>
+        /// Default storage container name
+        /// </summary>
+        public const string DefaultContainerName = "attachments";
+
+        /// <summary>
+        /// Default message user property to use for blob URI
+        /// </summary>
+        public const string DefaultMessagePropertyToIdentifyAttachmentBlob = "$attachment.blob";
+
+        /// <summary>
+        /// Default message property which contains the SAS URI used to fetch message body from blob.
+        /// </summary>
+        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
+    }
+}

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -7,8 +7,15 @@
     /// </summary>
     public static class AzureStorageAttachmentConfigurationExtensions
     {
-        internal const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
-        internal static TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
+        /// <summary>
+        /// Default message property which contains the SAS URI used to fetch message body from blob.
+        /// </summary>
+        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
+
+        /// <summary>
+        /// Default time the blob SAS URI is valid for.
+        /// </summary>
+        public static readonly TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
 
         /// <summary>
         /// Adds blob SAS URI configuration.

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -7,9 +7,6 @@
     /// </summary>
     public static class AzureStorageAttachmentConfigurationExtensions
     {
-        /// <summary>
-        /// Default time the blob SAS URI is valid for.
-        /// </summary>
         internal static readonly TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
 
         /// <summary>

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -8,11 +8,6 @@
     public static class AzureStorageAttachmentConfigurationExtensions
     {
         /// <summary>
-        /// Default message property which contains the SAS URI used to fetch message body from blob.
-        /// </summary>
-        public const string DefaultMessagePropertyToIdentitySasUri = "$attachment.sas.uri";
-
-        /// <summary>
         /// Default time the blob SAS URI is valid for.
         /// </summary>
         internal static readonly TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
@@ -26,7 +21,7 @@
         /// <returns></returns>
         public static AzureStorageAttachmentConfiguration WithBlobSasUri(
             this AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration,
-            string messagePropertyToIdentifySasUri = DefaultMessagePropertyToIdentitySasUri,
+            string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri,
             TimeSpan? sasTokenValidationTime = null)
         {
             if (azureStorageAttachmentConfiguration.UsingSas)

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentConfigurationExtensions.cs
@@ -15,14 +15,14 @@
         /// <summary>
         /// Default time the blob SAS URI is valid for.
         /// </summary>
-        public static readonly TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
+        internal static readonly TimeSpan DefaultSasTokenValidationTime = TimeSpan.FromDays(7);
 
         /// <summary>
         /// Adds blob SAS URI configuration.
         /// </summary>
         /// <param name="azureStorageAttachmentConfiguration"></param>
         /// <param name="messagePropertyToIdentifySasUri">The <see cref="Message"/> user property used for blob SAS URI.</param>
-        /// <param name="sasTokenValidationTime">The time blob SAS URI is valid for.</param>
+        /// <param name="sasTokenValidationTime">The time blob SAS URI is valid for. Default value is 7 days.</param>
         /// <returns></returns>
         public static AzureStorageAttachmentConfiguration WithBlobSasUri(
             this AzureStorageAttachmentConfiguration azureStorageAttachmentConfiguration,

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachmentExtensions.cs
@@ -23,7 +23,7 @@
         /// <param name="client"><see cref="IClientEntity"/>, <see cref="SubscriptionClient"/>, <see cref="QueueClient"/>, <see cref="MessageSender"/>, <see cref="MessageReceiver"/>, or <see cref="SessionClient"/> to register plugin with.</param>
         /// <param name="messagePropertyToIdentifySasUri">Message property name to be used to retrieve message SAS UI.</param>
         /// <returns>Registered plugin as <see cref="ServiceBusPlugin"/>.</returns>
-        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this IClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
+        public static ServiceBusPlugin RegisterAzureStorageAttachmentPluginForReceivingOnly(this IClientEntity client, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri)
         {
             var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
 

--- a/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
+++ b/src/ServiceBus.AttachmentPlugin/MessageExtensions.cs
@@ -30,7 +30,7 @@
         /// <param name="message"><see cref="Message"/></param>
         /// <param name="messagePropertyToIdentifySasUri">Message property which contains the SAS URI used to fetch message body from blob.</param>
         /// <returns><see cref="Message"/> with body downloaded from Azure Storage blob.</returns>
-        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationExtensions.DefaultMessagePropertyToIdentitySasUri)
+        public static async Task<Message> DownloadAzureStorageAttachment(this Message message, string messagePropertyToIdentifySasUri = AzureStorageAttachmentConfigurationConstants.DefaultMessagePropertyToIdentitySasUri)
         {
             var plugin = new ReceiveOnlyAzureStorageAttachment(messagePropertyToIdentifySasUri);
             return await plugin.AfterMessageReceive(message).ConfigureAwait(false);


### PR DESCRIPTION
Continuing along the lines of PR #189, this PR makes 
`DefaultMessagePropertyToIdentitySasUri` and `DefaultSasTokenValidationTime` public.

Again, the reason being that the default values can be used by consumers in order (for example) to implement cleanup.