### PR TITLE
Transient error happening in container existence check will lead to container not found exception

### DIFF
--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -46,14 +46,16 @@
             try
             {
                 // Will only work for Shared Key or Account SAS. For Container SAS will throw an exception.
-                if (! await container.ExistsAsync().ConfigureAwait(false))
+                if (! await container.ExistsAsync().ConfigureAwait(false)) 
                 {
                     await container.CreateIfNotExistsAsync().ConfigureAwait(false);
                 }
             }
-            catch (StorageException)
+            catch (StorageException exception)
             {
                 // swallow in case a container SAS is used
+                if (exception.RequestInformation.HttpStatusCode != (int)System.Net.HttpStatusCode.Forbidden)
+                    throw exception;
             }
 
             var blobName = configuration.BlobNameResolver(message);

--- a/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
+++ b/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs
@@ -55,7 +55,9 @@
             {
                 // swallow in case a container SAS is used
                 if (exception.RequestInformation.HttpStatusCode != (int)System.Net.HttpStatusCode.Forbidden)
-                    throw exception;
+                {
+                    throw;
+                }
             }
 
             var blobName = configuration.BlobNameResolver(message);


### PR DESCRIPTION
### Fix #258 
### Bug description
We found that transient network errors (e.g., 503 server busy or timeout) may fail the [ExistsAsync](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/a3739a16ceb0a4a10a23b7f82c3ff868a0ee019d/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs#L49) SDK API. More precisely, if the `container.ExistsAsync()` fails due to transient error(like service unavailable), the exception will be swallowed by the `catch` block. Therefore, the following [line of code](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/a3739a16ceb0a4a10a23b7f82c3ff868a0ee019d/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs#L66) will fail due to container not found exception.
```
try
{
    // Will only work for Shared Key or Account SAS. For Container SAS will throw an exception.
    if (! await container.ExistsAsync().ConfigureAwait(false))
    {
        await container.CreateIfNotExistsAsync().ConfigureAwait(false);
    }
}
catch (StorageException)
{
    // swallow in case a container SAS is used
}
...
await blob.UploadFromByteArrayAsync(message.Body, 0, message.Body.Length).ConfigureAwait(false);
```
and the output error message is `Microsoft.Azure.Storage.StorageException : The specified container does not exist`.

### How to reproduce
Transient errors like 503 service unavailable are likely to happen when creating container, consequently the method `container.ExistsAsync()` will fail. Hence, [this line](https://github.com/SeanFeldman/ServiceBus.AttachmentPlugin/blob/a3739a16ceb0a4a10a23b7f82c3ff868a0ee019d/src/ServiceBus.AttachmentPlugin/AzureStorageAttachment.cs#L66) will fail due to container not found exception.
### Expected behaviour
The exception should be checked in the catch block to decide whether to swallow/retry/rethrow depending on the exception type. For example, if it is caused by some transient error, it can either retry or just rethrow the exception.
### **Additional context**
This bug is similar to the #258 we found. We are willing to send a PR to help on this issue, if retry/rethrow the transient error exception is considered as a better practice than swallow.